### PR TITLE
Add SECURITY.md - Vulnerability Reporting Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+The Sarvam AI team takes security issues seriously. We appreciate your efforts to responsibly disclose your findings.
+
+**Please do NOT report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Instead, please report them via email to: **security@sarvam.ai**
+
+### What to Include
+
+To help us triage and prioritize, please include as much of the following as possible:
+
+- Type of vulnerability (e.g., injection, information disclosure, authentication bypass, etc.)
+- Affected component(s) (API, SDK, dashboard, specific repository, etc.)
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if available)
+- Impact assessment of the vulnerability
+- Any suggested remediation steps
+
+### What to Expect
+
+- **Acknowledgment**: We will acknowledge receipt of your report within **3 business days**.
+- **Assessment**: We will investigate and provide an initial assessment within **10 business days**.
+- **Resolution**: We aim to resolve confirmed vulnerabilities within **30-90 days**, depending on severity and complexity.
+- **Disclosure**: We will coordinate with you on public disclosure timing. We request a minimum of **90 days** before any public disclosure.
+
+### Scope
+
+The following are in scope for security reports:
+
+- Sarvam AI APIs (api.sarvam.ai)
+- Sarvam AI Dashboard (dashboard.sarvam.ai)
+- Sarvam AI SDKs and client libraries
+- Sarvam AI public-facing infrastructure (*.sarvam.ai)
+- This repository and other Sarvam AI open source projects
+
+### Out of Scope
+
+- Vulnerabilities in third-party dependencies (report these to the respective maintainers)
+- Social engineering attacks against Sarvam AI employees
+- Denial of service (DoS/DDoS) attacks
+- Issues that require physical access to a user's device
+- Automated scanner output without a validated proof of concept
+
+### Safe Harbor
+
+We support safe harbor for security researchers who:
+
+- Make a good faith effort to avoid privacy violations, data destruction, and service disruption
+- Only interact with accounts you own or with explicit permission of the account holder
+- Do not exploit a vulnerability beyond what is necessary to confirm it exists
+- Report vulnerabilities promptly and do not publicly disclose until we have had reasonable time to address them
+
+We will not pursue legal action against researchers who follow this policy.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | Yes       |
+
+## Security Updates
+
+Security patches and updates will be communicated through:
+
+- GitHub Security Advisories on the affected repository
+- Release notes for patched versions
+
+## Contact
+
+For security-related inquiries: **security@sarvam.ai**
+
+For general questions: Open an [issue](https://github.com/sarvamai/sarvam-ai-cookbook/issues) or join the [Discord](https://discord.com/invite/8ka56wQaT3).


### PR DESCRIPTION
## Summary

- Adds a `SECURITY.md` file with a clear vulnerability disclosure policy
- The current `CONTRIBUTING.MD` mentions that sensitive bugs should be sent by email, but does not provide a security contact address
- This leaves security researchers with no clear way to report vulnerabilities responsibly

## What's Included

- **Reporting instructions**: Clear steps for how to report security issues privately
- **Response timelines**: Acknowledgment within 3 business days, assessment within 10 business days
- **Scope definition**: What's in scope and out of scope for security reports
- **Safe harbor statement**: Legal protection for good-faith security researchers
- **Supported versions**: Which versions receive security patches

## Why This Matters

Without a `SECURITY.md`, GitHub cannot enable the "Security" tab's private vulnerability reporting feature, and researchers default to opening public issues — which risks exposing vulnerabilities before they are patched.

## References

- [GitHub security policy documentation](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)
- Current `CONTRIBUTING.MD` line: _"sensitive bugs must be sent by email"_ (no email specified)