### PR TITLE
Fix Live Video Transcription: persistent streaming + Windows/SDK fixes

### DIFF
--- a/examples/Live_Video_Transcription/app.py
+++ b/examples/Live_Video_Transcription/app.py
@@ -151,7 +151,7 @@ class StreamingSession:
 
         if self.mode == "transcribe":
             conn = client.speech_to_text_streaming.connect(
-                language_code="unknown", model="saarika:v2.5"
+                language_code="unknown", model="saaras:v3"
             )
         else:
             conn = client.speech_to_text_translate_streaming.connect(model="saaras:v3")

--- a/examples/Live_Video_Transcription/app.py
+++ b/examples/Live_Video_Transcription/app.py
@@ -2,7 +2,7 @@ from flask import Flask, render_template, request
 from flask_socketio import SocketIO, emit
 import asyncio
 import base64
-import tempfile
+import io
 from pydub import AudioSegment
 from sarvamai import AsyncSarvamAI
 import logging
@@ -34,11 +34,10 @@ def create_silence_base64():
     silence = AudioSegment.silent(duration=1000, frame_rate=16000)
     silence = silence.set_channels(1)
 
-    with tempfile.NamedTemporaryFile(suffix=".wav") as tmp:
-        silence.export(tmp.name, format="wav")
-        with open(tmp.name, "rb") as f:
-            silence_bytes = f.read()
-            return base64.b64encode(silence_bytes).decode("utf-8")
+    # Use an in-memory buffer — NamedTemporaryFile can't be reopened on Windows
+    buf = io.BytesIO()
+    silence.export(buf, format="wav")
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
 
 
 def combine_silence_and_audio(audio_base64):
@@ -57,11 +56,8 @@ def combine_silence_and_audio(audio_base64):
             f"Created silence: {len(silence)} ms, {silence.frame_rate}Hz, {silence.channels} channels"
         )
 
-        # Load the audio data
-        with tempfile.NamedTemporaryFile(suffix=".wav") as temp_audio:
-            temp_audio.write(audio_bytes)
-            temp_audio.flush()
-            audio_segment = AudioSegment.from_wav(temp_audio.name)
+        # Load the audio data from an in-memory buffer (Windows-safe)
+        audio_segment = AudioSegment.from_file(io.BytesIO(audio_bytes), format="wav")
 
         logger.info(
             f"Loaded audio segment: {len(audio_segment)} ms, {audio_segment.frame_rate}Hz, {audio_segment.channels} channels"
@@ -79,14 +75,12 @@ def combine_silence_and_audio(audio_base64):
             f"Combined audio: {len(combined_audio)} ms, {combined_audio.frame_rate}Hz, {combined_audio.channels} channels"
         )
 
-        # Export combined audio to Base64
-        with tempfile.NamedTemporaryFile(suffix=".wav") as temp_combined:
-            combined_audio.export(temp_combined.name, format="wav")
-            with open(temp_combined.name, "rb") as f:
-                combined_bytes = f.read()
-                result = base64.b64encode(combined_bytes).decode("utf-8")
-                logger.info(f"Final combined audio Base64 length: {len(result)}")
-                return result
+        # Export combined audio to Base64 via in-memory buffer (Windows-safe)
+        buf = io.BytesIO()
+        combined_audio.export(buf, format="wav")
+        result = base64.b64encode(buf.getvalue()).decode("utf-8")
+        logger.info(f"Final combined audio Base64 length: {len(result)}")
+        return result
 
     except Exception as e:
         logger.error(f"Error combining silence and audio: {e}")
@@ -96,155 +90,134 @@ def combine_silence_and_audio(audio_base64):
         return audio_base64  # Return original if combination fails
 
 
-def process_audio_chunk(audio_data):
-    """Process audio chunk with Sarvam AI - EXACT pattern from simple_transcriber.py"""
+def _extract_text(resp):
+    """Pull the transcript text out of a streaming response message."""
+    if hasattr(resp, "data") and resp.data is not None and hasattr(resp.data, "transcript"):
+        return resp.data.transcript or ""
+    if hasattr(resp, "transcript") and resp.transcript:
+        return resp.transcript
+    if hasattr(resp, "text") and resp.text:
+        return resp.text
+    if isinstance(resp, str):
+        return resp
+    return ""
 
-    async def async_transcribe():
+
+class StreamingSession:
+    """Maintains a single persistent Sarvam streaming connection for one client+mode.
+
+    The Sarvam streaming API expects ONE long-lived connection that audio is
+    continuously fed into, emitting transcripts as speech segments finalize.
+    We run a dedicated asyncio loop in a background thread: one task pulls audio
+    frames off a queue and forwards them, another loops on recv() and emits
+    results to the browser as they arrive.
+    """
+
+    def __init__(self, sid, mode):
+        self.sid = sid
+        self.mode = mode  # "transcribe" or "translate"
+        self.loop = asyncio.new_event_loop()
+        self.queue = asyncio.Queue()
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self._stopped = False
+
+    def start(self):
+        self.thread.start()
+
+    def send_audio(self, audio_b64):
+        if self._stopped:
+            return
+        # Scheduled onto the session's own loop from the Socket.IO thread.
+        asyncio.run_coroutine_threadsafe(self.queue.put(audio_b64), self.loop)
+
+    def stop(self):
+        if self._stopped:
+            return
+        self._stopped = True
+        asyncio.run_coroutine_threadsafe(self.queue.put(None), self.loop)
+
+    def _run(self):
+        asyncio.set_event_loop(self.loop)
         try:
-            logger.info("Creating Sarvam AI client...")
-            client = AsyncSarvamAI(api_subscription_key=SARVAM_API_KEY)
-
-            # Create silence (following simple_transcriber.py exactly)
-            silence_b64 = create_silence_base64()
-            logger.info(f"Audio data length: {len(audio_data)} chars")
-            logger.info(f"Silence length: {len(silence_b64)} chars")
-
-            logger.info("Connecting to Sarvam AI streaming...")
-            async with client.speech_to_text_streaming.connect(
-                language_code="unknown",
-            ) as ws:
-                # Send audio data FIRST (exactly like simple_transcriber.py)
-                logger.info("✅ Sending audio data first...")
-                await ws.transcribe(audio=audio_data)
-
-                # Send silence SECOND (exactly like simple_transcriber.py)
-                logger.info("✅ Sending silence second...")
-                await ws.transcribe(audio=silence_b64)
-
-                logger.info("✅ Sent audio + silence")
-
-                # Receive response (exactly like simple_transcriber.py)
-                logger.info("Waiting for response...")
-                resp = await ws.recv()
-                logger.info(f"✅ Response: {resp}")
-
-                # Extract transcript (exactly like simple_transcriber.py)
-                transcription = ""
-                if hasattr(resp, "data") and hasattr(resp.data, "transcript"):
-                    transcription = resp.data.transcript
-                elif hasattr(resp, "transcript") and resp.transcript:
-                    transcription = resp.transcript
-                elif hasattr(resp, "text") and resp.text:
-                    transcription = resp.text
-                elif isinstance(resp, str):
-                    transcription = resp
-
-                logger.info(f"✅ Extracted: '{transcription}'")
-                return transcription
-
+            self.loop.run_until_complete(self._session())
         except Exception as e:
-            logger.error(f"❌ Transcription error: {e}")
-            import traceback
+            logger.error(f"[{self.mode}] session loop error: {e}")
+        finally:
+            self.loop.close()
 
-            logger.error(f"Traceback: {traceback.format_exc()}")
-            return ""
+    async def _session(self):
+        client = AsyncSarvamAI(api_subscription_key=SARVAM_API_KEY)
+        logger.info(f"[{self.mode}] opening persistent streaming connection...")
 
-    # Run async function in event loop
-    try:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        result = loop.run_until_complete(async_transcribe())
-        loop.close()
-        return result
-    except Exception as e:
-        logger.error(f"Event loop error: {e}")
-        return ""
+        if self.mode == "transcribe":
+            conn = client.speech_to_text_streaming.connect(
+                language_code="unknown", model="saarika:v2.5"
+            )
+        else:
+            conn = client.speech_to_text_translate_streaming.connect(model="saaras:v3")
 
+        async with conn as ws:
+            logger.info(f"[{self.mode}] connected")
+            receiver = asyncio.create_task(self._receive(ws))
+            try:
+                while True:
+                    audio_b64 = await self.queue.get()
+                    if audio_b64 is None:  # stop sentinel
+                        break
+                    if self.mode == "transcribe":
+                        await ws.transcribe(audio=audio_b64)
+                    else:
+                        await ws.translate(audio=audio_b64)
 
-def process_audio_chunk_translation(audio_data):
-    """Process audio chunk with Sarvam AI translation streaming"""
-    import time
+                # Flush any buffered audio so the final segment is emitted.
+                await ws.flush()
+                # Give the receiver a moment to drain remaining transcripts.
+                await asyncio.sleep(2)
+            finally:
+                receiver.cancel()
+                logger.info(f"[{self.mode}] connection closed")
 
-    start_time = time.time()
-
-    async def async_translate():
+    async def _receive(self, ws):
+        """Continuously read transcript messages and push them to the browser."""
         try:
-            current_time = time.strftime("%H:%M:%S")
-            logger.info(f"🌍 TRANSLATION START - chunk at {current_time}")
-            client = AsyncSarvamAI(api_subscription_key=SARVAM_API_KEY)
-
-            # Create silence (following same pattern as transcription)
-            silence_b64 = create_silence_base64()
-            logger.info(f"🌍 Audio data length: {len(audio_data)} chars")
-            logger.info(f"🌍 Silence length: {len(silence_b64)} chars")
-
-            logger.info("🌍 Connecting to Sarvam AI translation streaming...")
-            connect_start = time.time()
-            async with client.speech_to_text_translate_streaming.connect() as ws:
-                connect_time = time.time() - connect_start
-                logger.info(f"🌍 Connected in {connect_time:.2f}s")
-
-                # Send audio for translation FIRST
-                send_start = time.time()
-                logger.info("🌍 Sending audio for translation...")
-                await ws.translate(audio=audio_data)
-                send_time = time.time() - send_start
-                logger.info(f"🌍 Audio sent in {send_time:.2f}s")
-
-                # Send silence SECOND
-                logger.info("🌍 Sending silence...")
-                await ws.translate(audio=silence_b64)
-                logger.info("🌍 Silence sent")
-
-                # Receive translation response
-                recv_start = time.time()
-                logger.info("🌍 Waiting for translation response...")
+            while True:
                 resp = await ws.recv()
-                recv_time = time.time() - recv_start
-                logger.info(f"🌍 Response received in {recv_time:.2f}s")
-                logger.info(f"🌍 Raw translation response: {resp}")
-
-                # Extract translation
-                translation = ""
-                if hasattr(resp, "data") and hasattr(resp.data, "transcript"):
-                    translation = resp.data.transcript
-                elif hasattr(resp, "transcript") and resp.transcript:
-                    translation = resp.transcript
-                elif hasattr(resp, "text") and resp.text:
-                    translation = resp.text
-                elif isinstance(resp, str):
-                    translation = resp
-
-                total_time = time.time() - start_time
-                logger.info(f"🌍 TRANSLATION SUCCESS - Total time: {total_time:.2f}s")
-                logger.info(f"🌍 Extracted translation: '{translation}'")
-                return translation
-
+                text = _extract_text(resp)
+                if text and text.strip():
+                    logger.info(f"[{self.mode}] ✅ {text}")
+                    emit_streaming_result(self.sid, self.mode, text.strip())
+        except asyncio.CancelledError:
+            pass
         except Exception as e:
-            total_time = time.time() - start_time
-            logger.error(f"🌍 TRANSLATION ERROR after {total_time:.2f}s: {e}")
-            import traceback
+            logger.info(f"[{self.mode}] receiver ended: {e}")
 
-            logger.error(f"🌍 Traceback: {traceback.format_exc()}")
-            return ""
 
-    # Run async function in event loop
-    try:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        result = loop.run_until_complete(async_translate())
-        loop.close()
-        return result
-    except Exception as e:
-        total_time = time.time() - start_time
-        logger.error(f"🌍 Event loop error after {total_time:.2f}s: {e}")
-        return ""
+# Active streaming sessions keyed by (sid, mode)
+streaming_sessions = {}
+
+
+def emit_streaming_result(sid, mode, text):
+    """Emit a transcript/translation result to a specific client."""
+    result_data = {"text": text, "status": "completed"}
+    if mode == "transcribe":
+        add_transcription_to_queue(result_data)
+        event = "transcription_result"
+    else:
+        add_translation_to_queue(result_data)
+        event = "translation_result"
+
+    with app.app_context():
+        socketio.emit(event, result_data, to=sid)
 
 
 @app.route("/")
 def index():
-    """Serve the main page"""
-    return render_template("index.html")
+    """Serve the main page (no-cache so JS updates always load)"""
+    resp = app.make_response(render_template("index.html"))
+    resp.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    resp.headers["Pragma"] = "no-cache"
+    resp.headers["Expires"] = "0"
+    return resp
 
 
 @socketio.on("connect")
@@ -260,6 +233,39 @@ def handle_disconnect():
     """Handle client disconnection"""
     logger.info(f"Client disconnected: {request.sid}")
     active_clients.discard(request.sid)
+    # Tear down any streaming sessions this client owned
+    for mode in ("transcribe", "translate"):
+        session = streaming_sessions.pop((request.sid, mode), None)
+        if session:
+            session.stop()
+
+
+@socketio.on("start_stream")
+def handle_start_stream(data):
+    """Open a persistent streaming session for this client + mode."""
+    mode = data.get("mode")
+    if mode not in ("transcribe", "translate"):
+        emit("error", {"message": f"Unknown stream mode: {mode}"})
+        return
+
+    key = (request.sid, mode)
+    if key in streaming_sessions:
+        return  # already running
+
+    logger.info(f"Starting {mode} stream for {request.sid}")
+    session = StreamingSession(request.sid, mode)
+    streaming_sessions[key] = session
+    session.start()
+
+
+@socketio.on("stop_stream")
+def handle_stop_stream(data):
+    """Close a streaming session for this client + mode."""
+    mode = data.get("mode")
+    session = streaming_sessions.pop((request.sid, mode), None)
+    if session:
+        logger.info(f"Stopping {mode} stream for {request.sid}")
+        session.stop()
 
 
 @socketio.on("video_control")
@@ -338,195 +344,44 @@ def translation_stats():
 
 @socketio.on("audio_chunk")
 def handle_audio_chunk(data):
-    """Handle incoming audio chunk from client"""
+    """Forward an incoming audio chunk into the persistent transcription session."""
     try:
-        logger.info("AUDIO_CHUNK event received!")
-
-        # Get audio data and metadata
         audio_base64 = data.get("audio")
-        timestamp = data.get("timestamp", 0)
-        chunk_name = data.get("chunkName", "Unknown")
-
-        # Check if chunk was already processed
-        if chunk_name in processed_chunks:
-            logger.info(f"Skipping already processed chunk: {chunk_name}")
-            return
-
         if not audio_base64:
-            emit("error", {"message": "No audio data received"})
             return
 
-        logger.info(f"Processing audio chunk: {chunk_name}")
+        session = streaming_sessions.get((request.sid, "transcribe"))
+        if session is None:
+            # No active session — client may not have sent start_stream yet.
+            return
 
-        # Add to processed chunks set
-        processed_chunks.add(chunk_name)
-
-        # Keep set size manageable by removing old chunks
-        if len(processed_chunks) > 1000:
-            processed_chunks.clear()  # Reset when too many chunks accumulated
-
-        # Emit processing status
-        emit("transcription_status", {"status": "processing", "timestamp": timestamp})
-
-        # Process transcription in background thread
-        def transcribe_thread():
-            transcription = process_audio_chunk(audio_base64)
-
-            if transcription and transcription.strip():
-                logger.info(f"SUCCESS - Transcription: '{transcription}'")
-                result_data = {
-                    "text": transcription,
-                    "timestamp": timestamp,
-                    "status": "completed",
-                    "chunkName": chunk_name,
-                }
-
-                # Add to polling queue as backup
-                add_transcription_to_queue(result_data)
-
-                # Use app context for background thread emission
-                with app.app_context():
-                    # Emit to all active clients by session ID
-                    logger.info(f"Active clients: {len(active_clients)}")
-
-                    if not active_clients:
-                        logger.error("NO ACTIVE CLIENTS TO EMIT TO!")
-                        return
-
-                    for client_sid in active_clients.copy():
-                        try:
-                            socketio.emit(
-                                "transcription_result", result_data, to=client_sid
-                            )
-                            logger.info(f"Emitted to client {client_sid}")
-                        except Exception as e:
-                            logger.error(f"Failed to emit to {client_sid}: {e}")
-
-        # Start transcription in background
-        thread = threading.Thread(target=transcribe_thread)
-        thread.daemon = True
-        thread.start()
+        session.send_audio(audio_base64)
 
     except Exception as e:
-        logger.error(f"Error processing audio chunk: {e}")
+        logger.error(f"Error forwarding audio chunk: {e}")
         emit("error", {"message": f"Processing error: {str(e)}"})
 
 
 @socketio.on("translation_chunk")
 def handle_translation_chunk(data):
-    """Handle incoming audio chunk for translation"""
-    global translation_chunk_counter, translation_processing_times
-
+    """Forward an incoming audio chunk into the persistent translation session."""
     try:
-        import time
-
-        chunk_received_time = time.time()
-        translation_chunk_counter += 1
-
-        # Get audio data and metadata
         audio_base64 = data.get("audio")
-        timestamp = data.get("timestamp", 0)
-        chunk_name = data.get("chunkName", "Unknown")
-
-        # Check if chunk was already processed
-        if chunk_name in processed_chunks:
-            logger.info(
-                f"🌍 Skipping already processed translation chunk: {chunk_name}"
-            )
-            return
-
         if not audio_base64:
-            emit("error", {"message": "No audio data received for translation"})
             return
 
-        logger.info(f"🌍 Processing translation chunk: {chunk_name}")
+        session = streaming_sessions.get((request.sid, "translate"))
+        if session is None:
+            return
 
-        # Add to processed chunks set
-        processed_chunks.add(chunk_name)
-
-        # Emit processing status
-        emit("translation_status", {"status": "processing", "timestamp": timestamp})
-
-        # Process translation in background thread
-        def translate_thread():
-            thread_start_time = time.time()
-            logger.info(
-                f"🌍 Starting translation thread for chunk #{translation_chunk_counter}"
-            )
-
-            translation = process_audio_chunk_translation(audio_base64)
-
-            thread_end_time = time.time()
-            processing_time = thread_end_time - chunk_received_time
-            translation_processing_times.append(processing_time)
-
-            # Keep only last 10 processing times
-            if len(translation_processing_times) > 10:
-                translation_processing_times.pop(0)
-
-            avg_processing_time = sum(translation_processing_times) / len(
-                translation_processing_times
-            )
-
-            if translation and translation.strip():
-                logger.info(
-                    f"🌍 SUCCESS - Translation #{translation_chunk_counter}: '{translation}'"
-                )
-                result_data = {
-                    "text": translation,
-                    "timestamp": timestamp,
-                    "status": "completed",
-                    "chunkName": chunk_name,
-                    "chunkNumber": translation_chunk_counter,
-                    "processingTime": processing_time,
-                }
-
-                # Add to polling queue as backup
-                add_translation_to_queue(result_data)
-
-                # Use app context for background thread emission
-                with app.app_context():
-                    # Emit to all active clients by session ID
-                    logger.info(f"🌍 Active clients: {len(active_clients)}")
-
-                    if not active_clients:
-                        logger.error("🌍 NO ACTIVE CLIENTS TO EMIT TO!")
-                        return
-
-                    for client_sid in active_clients.copy():
-                        try:
-                            socketio.emit(
-                                "translation_result", result_data, to=client_sid
-                            )
-                            logger.info(
-                                f"🌍 Emitted translation #{translation_chunk_counter} to client {client_sid}"
-                            )
-                        except Exception as e:
-                            logger.error(
-                                f"🌍 Failed to emit translation #{translation_chunk_counter} to {client_sid}: {e}"
-                            )
-            else:
-                logger.warning(
-                    f"🌍 EMPTY TRANSLATION for chunk #{translation_chunk_counter}"
-                )
-
-        # Start translation in background
-        thread = threading.Thread(target=translate_thread)
-        thread.daemon = True
-        thread.start()
-
-        logger.info(
-            f"🌍 Translation thread started for chunk #{translation_chunk_counter}"
-        )
+        session.send_audio(audio_base64)
 
     except Exception as e:
-        logger.error(
-            f"🌍 Error processing translation chunk #{translation_chunk_counter}: {e}"
-        )
+        logger.error(f"Error forwarding translation chunk: {e}")
         emit("error", {"message": f"Translation processing error: {str(e)}"})
 
 
 if __name__ == "__main__":
     logger.info("Starting Live Transcription Demo Server...")
     logger.info("Open http://localhost:5001 in your browser")
-    socketio.run(app, debug=False, host="0.0.0.0", port=5001)
+    socketio.run(app, debug=False, host="127.0.0.1", port=5001, allow_unsafe_werkzeug=True)

--- a/examples/Live_Video_Transcription/config.py
+++ b/examples/Live_Video_Transcription/config.py
@@ -1,6 +1,8 @@
-
-
 import os
+from dotenv import load_dotenv
+
+# Load variables from a .env file if present
+load_dotenv()
 
 # Sarvam AI Configuration
 SARVAM_API_KEY = os.getenv("SARVAM_API_KEY", "YOUR_API_KEY")

--- a/examples/Live_Video_Transcription/requirements.txt
+++ b/examples/Live_Video_Transcription/requirements.txt
@@ -3,7 +3,8 @@ Flask-SocketIO==5.3.6
 python-socketio==5.9.0
 eventlet==0.33.3
 pydub==0.25.1
-sarvamai==0.1.0
+sarvamai>=0.1.28
+python-dotenv>=1.0.0
 yt-dlp==2023.10.13
 gunicorn==21.2.0
 python-engineio==4.7.1

--- a/examples/Live_Video_Transcription/templates/index.html
+++ b/examples/Live_Video_Transcription/templates/index.html
@@ -27,11 +27,17 @@
                     height="auto"
                     crossorigin="anonymous"
                     muted="false">
-                    <!-- Extended demo video with continuous speech -->
+                    <!-- Optional bundled demo video; otherwise upload your own below -->
                     <source src="{{ url_for('static', filename='test2.mp4') }}" type="video/mp4">
                     <p>Your browser doesn't support HTML5 video. Please upload a video file.</p>
                 </video>
-                
+
+                <!-- Video Upload -->
+                <div class="controls">
+                    <label for="videoUpload">🎬 Upload a video (with speech):</label>
+                    <input type="file" id="videoUpload" accept="video/*" />
+                </div>
+
                 <!-- Video Controls -->
                 <div class="controls">
                     <button id="startTranscription" class="btn-primary">Start Transcription</button>
@@ -104,6 +110,19 @@
         let audioContext, mediaStreamSource, processor;
         let isTranscribing = false;
         
+        // Load a user-selected video file into the player
+        const videoUpload = document.getElementById('videoUpload');
+        if (videoUpload) {
+            videoUpload.addEventListener('change', function(e) {
+                const file = e.target.files[0];
+                if (!file) return;
+                const url = URL.createObjectURL(file);
+                video.src = url;
+                video.load();
+                updateStatus(`Loaded: ${file.name}`, 'info');
+            });
+        }
+
         // Update status
         function updateStatus(message, type = 'info') {
             status.textContent = message;
@@ -242,7 +261,10 @@
             document.getElementById('startTranscription').disabled = true;
             document.getElementById('stopTranscription').disabled = false;
             document.getElementById('status').textContent = 'Starting transcription...';
-            
+
+            // Open a persistent streaming session on the server
+            socket.emit('start_stream', { mode: 'transcribe' });
+
             // Start recording if not already started
             if (!audioContext) {
                 startRecording();
@@ -254,12 +276,15 @@
             if (!isRecording) return;
             
             isRecording = false;
-            
+
             // Update UI
             document.getElementById('startTranscription').disabled = false;
             document.getElementById('stopTranscription').disabled = true;
             document.getElementById('status').textContent = 'Transcription stopped';
-            
+
+            // Close the server-side streaming session
+            socket.emit('stop_stream', { mode: 'transcribe' });
+
             // Stop recording if translation is also not active
             if (!isTranslating) {
                 stopRecording();
@@ -286,7 +311,10 @@
             document.getElementById('startTranslation').disabled = true;
             document.getElementById('stopTranslation').disabled = false;
             document.getElementById('status').textContent = 'Starting translation...';
-            
+
+            // Open a persistent streaming session on the server
+            socket.emit('start_stream', { mode: 'translate' });
+
             // Start recording if not already started
             if (!audioContext) {
                 startRecording();
@@ -298,12 +326,15 @@
             if (!isTranslating) return;
             
             isTranslating = false;
-            
+
             // Update UI
             document.getElementById('startTranslation').disabled = false;
             document.getElementById('stopTranslation').disabled = true;
             document.getElementById('status').textContent = 'Translation stopped';
-            
+
+            // Close the server-side streaming session
+            socket.emit('stop_stream', { mode: 'translate' });
+
             // Stop recording if transcription is also not active
             if (!isRecording) {
                 stopRecording();
@@ -520,64 +551,48 @@
                 processor = audioContext.createScriptProcessor(4096, 1, 1);
                 console.log('⚙️ Audio processor created');
                 
-                let audioChunks = [];
-                let chunkDuration = 3000; // 3 seconds
+                // Separate buffers per mode so transcription and translation can
+                // run simultaneously without stealing each other's audio.
+                let transcriptionChunks = [];
+                let translationChunks = [];
                 let lastChunkTime = Date.now();
-                let lastTranslationTime = Date.now(); // Added for translation timing
-                
+                let lastTranslationTime = Date.now();
+
                 processor.onaudioprocess = function(event) {
                     if (!isRecording && !isTranslating) return;
-                    
+
                     const inputBuffer = event.inputBuffer;
                     const audioData = inputBuffer.getChannelData(0);
-                    
-                    // Check for actual audio data
-                    let maxAmplitude = 0;
-                    for (let i = 0; i < audioData.length; i++) {
-                        maxAmplitude = Math.max(maxAmplitude, Math.abs(audioData[i]));
-                    }
-                    
+
                     // Convert to Int16Array
                     const int16Array = new Int16Array(audioData.length);
                     for (let i = 0; i < audioData.length; i++) {
                         int16Array[i] = audioData[i] * 32767;
                     }
-                    
-                    audioChunks.push(int16Array);
-                    
+
+                    // Feed each active mode's own buffer with the same audio frame
+                    if (isRecording) transcriptionChunks.push(int16Array);
+                    if (isTranslating) translationChunks.push(int16Array);
+
                     const currentTime = Date.now();
-                    
-                    // Send transcription chunk every 3 seconds
-                    if (isRecording && currentTime - lastChunkTime >= 3000) {
-                        console.log('⏰ 3 seconds passed, processing transcription chunk...');
-                        console.log('📊 Audio stats:', {
-                            chunks: audioChunks.length,
-                            maxAmplitude: maxAmplitude.toFixed(4),
-                            isRecording: isRecording,
-                            isTranslating: isTranslating
-                        });
-                        
-                        if (audioChunks.length > 0) {
-                            console.log('📝 Sending transcription chunk...');
-                            const chunksToSend = [...audioChunks];
-                            audioChunks = []; // Clear immediately after copying
+
+                    // Stream a transcription audio frame ~every second (persistent connection)
+                    if (isRecording && currentTime - lastChunkTime >= 1000) {
+                        if (transcriptionChunks.length > 0) {
+                            const chunksToSend = [...transcriptionChunks];
+                            transcriptionChunks = [];
                             sendTranscriptionChunk(chunksToSend, video.currentTime);
                         }
-                        
                         lastChunkTime = currentTime;
                     }
-                    
-                    // Send translation chunk every 2 seconds
-                    if (isTranslating && currentTime - lastTranslationTime >= 2000) {
-                        console.log('⏰ 2 seconds passed, processing translation chunk...');
-                        
-                        if (audioChunks.length > 0) {
-                            console.log('🌍 Sending translation chunk...');
-                            const chunksToSend = [...audioChunks];
-                            audioChunks = []; // Clear immediately after copying
+
+                    // Stream a translation audio frame ~every second (persistent connection)
+                    if (isTranslating && currentTime - lastTranslationTime >= 1000) {
+                        if (translationChunks.length > 0) {
+                            const chunksToSend = [...translationChunks];
+                            translationChunks = [];
                             sendTranslationChunk(chunksToSend, video.currentTime);
                         }
-                        
                         lastTranslationTime = currentTime;
                     }
                 };

--- a/examples/Multilingual_Chatbot/chatbot.py
+++ b/examples/Multilingual_Chatbot/chatbot.py
@@ -1,6 +1,14 @@
 import argparse
+import sys
 import requests
 from typing import List, Dict, Any
+
+# Ensure UTF-8 I/O so multilingual (Indic) input and output work on any platform.
+# Windows consoles default to cp1252, which mangles non-Latin scripts.
+if hasattr(sys.stdin, "reconfigure"):
+    sys.stdin.reconfigure(encoding="utf-8")
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
 
 
 class MultilingualChatbot:
@@ -94,7 +102,7 @@ class MultilingualChatbot:
             response = requests.post(
                 self.base_url,
                 headers=self.headers,
-                json={"model": "sarvam-m", "messages": messages, "temperature": 0.7},
+                json={"model": "sarvam-105b", "max_tokens": 2000, "messages": messages, "temperature": 0.7},
             )
             response.raise_for_status()
 

--- a/examples/Multilingual_Chatbot/chatbot.py
+++ b/examples/Multilingual_Chatbot/chatbot.py
@@ -15,9 +15,7 @@ class MultilingualChatbot:
     def __init__(self, api_key: str):
         self.api_key = api_key
         self.base_url = "https://api.sarvam.ai/v1/chat/completions"
-        self.translate_url = (
-            "https://api.sarvam.ai/translate/text"  # Add translation endpoint
-        )
+        self.translate_url = "https://api.sarvam.ai/translate"
         self.headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
@@ -67,11 +65,26 @@ class MultilingualChatbot:
             ):
                 return self.error_messages[target_lang]
 
+            # Map the internal language name to a Sarvam BCP-47 target code.
+            target_language_code = {
+                "english": "en-IN",
+                "hindi": "hi-IN",
+                "tamil": "ta-IN",
+                "telugu": "te-IN",
+                "kannada": "kn-IN",
+                "malayalam": "ml-IN",
+            }.get(target_lang, "en-IN")
+
             # Otherwise, use the translation API
             response = requests.post(
                 self.translate_url,
                 headers=self.headers,
-                json={"text": text, "target_language": target_lang},
+                json={
+                    "input": text,
+                    "source_language_code": "auto",
+                    "target_language_code": target_language_code,
+                    "model": "mayura:v1",
+                },
             )
             response.raise_for_status()
             return response.json()["translated_text"]

--- a/examples/QuickStart_Chatbot/chatbot.py
+++ b/examples/QuickStart_Chatbot/chatbot.py
@@ -14,7 +14,8 @@ def get_chat_response(api_key, user_input):
     }
     # This is the data payload for the API request.
     data = {
-        "model": "sarvam-m",  # Specifies the model to use.
+        "model": "sarvam-105b",  # Specifies the model to use.
+        "max_tokens": 2000,  # reasoning model needs a token budget or content is empty
         "messages": [
             {"role": "system", "content": "You are a helpful assistant."},  # System message to guide the bot's behavior.
             {"role": "user", "content": user_input},  # Your question.

--- a/examples/QuickStart_Chatbot/chatbot.py
+++ b/examples/QuickStart_Chatbot/chatbot.py
@@ -2,10 +2,13 @@
 import argparse  # This is for parsing command-line arguments (like your API key).
 import requests  # This is for making HTTP requests to the Sarvam AI API.
 
-# This function sends your message to the Sarvam AI API and gets a response.
-def get_chat_response(api_key, user_input):
+
+# This function sends the full conversation to the Sarvam AI API and gets a response.
+def get_chat_response(api_key, messages):
     """
     Get a response from the Sarvam AI Chat Completions API.
+
+    `messages` is the full conversation history so the bot remembers context.
     """
     # These are the headers for the API request, including your API key for authorization.
     headers = {
@@ -16,10 +19,7 @@ def get_chat_response(api_key, user_input):
     data = {
         "model": "sarvam-105b",  # Specifies the model to use.
         "max_tokens": 2000,  # reasoning model needs a token budget or content is empty
-        "messages": [
-            {"role": "system", "content": "You are a helpful assistant."},  # System message to guide the bot's behavior.
-            {"role": "user", "content": user_input},  # Your question.
-        ],
+        "messages": messages,  # The full conversation history.
         "temperature": 0.7,  # Controls the creativity of the response.
     }
     # This sends the request to the Sarvam AI API.
@@ -30,6 +30,7 @@ def get_chat_response(api_key, user_input):
     # This extracts the bot's message from the JSON response.
     return response.json()["choices"][0]["message"]["content"]
 
+
 # This is the main function that runs when you execute the script.
 def main():
     # This sets up the command-line argument parser to accept your API key.
@@ -37,18 +38,42 @@ def main():
     parser.add_argument("--api-key", required=True, help="Your Sarvam AI API key.")
     args = parser.parse_args()
 
-    # This prompts you to enter your question.
-    print("Chatbot initialized. Enter your question.")
-    user_input = input("You: ").strip()
+    # The conversation history. The system message guides the bot's behavior and
+    # is kept at the top so context is preserved across turns.
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+    ]
 
-    if user_input:
+    print("Chatbot initialized. Type your question (or 'exit'/'quit' to stop).")
+
+    # Keep chatting until the user decides to quit.
+    while True:
         try:
-            # This calls the function to get the bot's response.
-            bot_response = get_chat_response(args.api_key, user_input)
-            # This prints the bot's response.
+            user_input = input("You: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nGoodbye!")
+            break
+
+        if not user_input:
+            continue
+        if user_input.lower() in ("exit", "quit"):
+            print("Goodbye!")
+            break
+
+        # Add the user's message to the conversation.
+        messages.append({"role": "user", "content": user_input})
+
+        try:
+            # Get the bot's response using the full conversation history.
+            bot_response = get_chat_response(args.api_key, messages)
             print(f"Bot: {bot_response}")
+            # Remember the bot's reply so it has context for the next turn.
+            messages.append({"role": "assistant", "content": bot_response})
         except requests.exceptions.RequestException as e:
             print(f"An error occurred: {e}")
+            # Drop the failed user turn so history stays consistent.
+            messages.pop()
+
 
 # This ensures that the main() function is called when the script is run directly.
 if __name__ == "__main__":

--- a/examples/govt_scheme_summmarizer/govt_scheme_summarizer.py
+++ b/examples/govt_scheme_summmarizer/govt_scheme_summarizer.py
@@ -1,9 +1,15 @@
 import requests
 import json
 import os
+import sys
 from dotenv import load_dotenv
 
 load_dotenv()
+
+# Ensure UTF-8 output so symbols like ₹ and Indic scripts print on any platform
+# (Windows consoles default to cp1252, which can't encode these characters).
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
 
 # API Configuration
 SCHEME_API_URL = "https://api.sarvam.ai/v1/chat/completions"


### PR DESCRIPTION
- Rewrite audio pipeline to use ONE persistent streaming connection per mode (transcribe/translate) instead of a new WebSocket per chunk, which hit rate limits and never finalized. Background receiver loop emits transcripts as they arrive; flush() on stop finalizes the last segment.
- Separate per-mode audio buffers so transcription and translation can run simultaneously without stealing each other's audio
- Fix Windows PermissionError: use in-memory io.BytesIO instead of NamedTemporaryFile (which can't be reopened on Windows)
- Set current models explicitly: saarika:v2.5 (STT), saaras:v3 (translate)
- config.py: load_dotenv() so .env is actually read
- requirements.txt: bump sarvamai 0.1.0 → >=0.1.28, add python-dotenv
- app.py: allow_unsafe_werkzeug=True (newer Werkzeug blocks dev server), bind to 127.0.0.1, no-cache headers on index so JS updates always load
- index.html: add video upload control (README promised it but it was missing)