### PR TITLE
Fix Regional_Doubt_Solver: model update + max_tokens

### DIFF
--- a/examples/Regional_Doubt_Solver/homework_helper.py
+++ b/examples/Regional_Doubt_Solver/homework_helper.py
@@ -41,7 +41,8 @@ def get_explanation(question: str, language_code: str, grade_level: int, api_key
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": question}
         ],
-        "model": "sarvam-m",
+        "model": "sarvam-105b",
+        "max_tokens": 2000,
         "temperature": 0.7
     }
     


### PR DESCRIPTION
## What this fixes

The `Regional_Doubt_Solver` homework helper used a deprecated model and could return empty responses.

### Changes
- **Model update**: `sarvam-m` → `sarvam-105b`
- **Add `max_tokens=2000`**: `sarvam-105b` is a reasoning model — without a token budget it can spend the budget on reasoning and return empty content.

(The language-identification endpoint `text-lid` and its `language_code` response field were verified against the current SDK — no change needed.)

### Testing
Verified end-to-end against the live API:
- English: *"What is photosynthesis?"* → detected `en-IN`, returned a clear grade-6 explanation.
- Hindi: *"प्रकाश संश्लेषण क्या है?"* → detected `hi-IN`, answered in Hindi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)