### PR TITLE
Fix AI_Presentation_Architect: model, robust JSON parsing, deps

### DIFF
--- a/examples/AI_Presentation_Architect/app.py
+++ b/examples/AI_Presentation_Architect/app.py
@@ -2,7 +2,7 @@ import streamlit as st
 import requests
 import json
 import io
-import pandas as pd
+import re
 from pptx import Presentation
 from pptx.util import Inches
 
@@ -30,12 +30,17 @@ def generate_english_presentation(topic: str, api_key: str, slide_count: int) ->
     You are an expert content creator. Generate a {slide_count}-slide presentation for the topic: '{topic}'.
     Return a single JSON array of objects. Each object must have "title" and "content" (a string with 3-4 bullet points, separated by newlines).
     """
-    payload = {"model": "sarvam-m", "messages": [{"role": "user", "content": prompt}]}
+    payload = {"model": "sarvam-105b", "max_tokens": 4000, "messages": [{"role": "user", "content": prompt}]}
     response = requests.post(CHAT_API_URL, headers=headers, json=payload)
     response.raise_for_status()
     response_text = response.json()["choices"][0]["message"]["content"]
-    if response_text.startswith("```json"):
-        response_text = response_text[7:-3].strip()
+    if not response_text:
+        raise ValueError("The model returned an empty response. Please try again, or reduce the slide count.")
+    # Strip code fences if the model wrapped the JSON in them.
+    response_text = response_text.strip()
+    if response_text.startswith("```"):
+        response_text = re.sub(r"^```(?:json)?\s*", "", response_text)
+        response_text = re.sub(r"\s*```$", "", response_text).strip()
     return json.loads(response_text)
 
 def translate_content(text: str, target_lang: str, api_key: str) -> str:

--- a/examples/AI_Presentation_Architect/requirements.txt
+++ b/examples/AI_Presentation_Architect/requirements.txt
@@ -1,4 +1,3 @@
 streamlit
 requests
 python-pptx
-pandas


### PR DESCRIPTION
## What this fixes

The `AI_Presentation_Architect` (multilingual PowerPoint generator) used a deprecated model and had brittle JSON parsing.

### Changes
- **Model**: `sarvam-m` → `sarvam-105b`, and added `max_tokens=4000` (needed to fit up to 10 slides of JSON; stays under the starter-tier 4096 cap).
- **Robust JSON parsing**: the old code did `response_text[7:-3]`, which only worked if the output was wrapped in exactly ` ```json … ``` ` and crashed (`AttributeError`) if `content` was `None`. Now it strips ` ``` `/` ```json ` fences via regex and raises a clear error on empty content.
- **Dependencies**: removed the unused `pandas` import and requirement (replaced with stdlib `re`).

(The `translate` and `python-pptx` logic were already correct and left unchanged.)

### Testing
Verified the full backend end-to-end against the live API (headless, bypassing the Streamlit UI):
1. Generated 3-slide JSON for "Benefits of solar energy in India" → parsed cleanly.
2. Translated titles/content to Hindi (e.g. *"भारत में सौर ऊर्जाः एक अवलोकन"*).
3. Built a valid 31.9 KB `.pptx` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)