### PR TITLE
Fix Indic Soundbox AI: update models and TTS language fallback

### DIFF
--- a/examples/Indic Soundbox AI/README.md
+++ b/examples/Indic Soundbox AI/README.md
@@ -1,7 +1,7 @@
 # Sarvam Indic Soundbox AI (Inspired from Paytm and PhonePe soundboxes)
 This Agent enables Indian merchants via their Soundbox (lets say Paytm or PhonePe Soundbox) to get insights about their Sales, How to grow their busines? in their local language of choice and also enables organisations like Paytm and PhonePe to connect with their merchants in a easier manner in indic languages.
 
-This uses Sarvam ASR (`saarika:v2.5`), Language Identification, the Sarvam-105B chat model and TTS (`bulbul:v3`) - all built on the Indic Stack.
+This uses Sarvam ASR (`saaras:v3`), Language Identification, the Sarvam-105B chat model and TTS (`bulbul:v3`) - all built on the Indic Stack.
 
 ## Project Structure
 

--- a/examples/Indic Soundbox AI/README.md
+++ b/examples/Indic Soundbox AI/README.md
@@ -1,7 +1,7 @@
 # Sarvam Indic Soundbox AI (Inspired from Paytm and PhonePe soundboxes)
 This Agent enables Indian merchants via their Soundbox (lets say Paytm or PhonePe Soundbox) to get insights about their Sales, How to grow their busines? in their local language of choice and also enables organisations like Paytm and PhonePe to connect with their merchants in a easier manner in indic languages.
 
-This uses Sarvam ASR, Language Indentification, Sarvam-M Thinking Model and TTS - all built on Indic Stack.
+This uses Sarvam ASR (`saarika:v2.5`), Language Identification, the Sarvam-105B chat model and TTS (`bulbul:v3`) - all built on the Indic Stack.
 
 ## Project Structure
 
@@ -41,11 +41,11 @@ This uses Sarvam ASR, Language Indentification, Sarvam-M Thinking Model and TTS 
 
 4.  **Set up Sarvam API Key:**
     Create a file named `.env` in the root of the project directory (next to `app.py`).
-    Add your (Sarvam API key)[https://dashboard.sarvam.ai] to this file:
+    Add your [Sarvam API key](https://dashboard.sarvam.ai) to this file:
     ```
     SARVAM_API_KEY='YOUR_SARVAM_API_KEY_HERE'
     ```
-    Replace `YOUR_SARVAM_API_KEY_HERE` with your actual key (e.g., `044317b1-21ac-402f-9b65-1d98a3dcf2fd` as per your example, but ideally use your own).
+    Replace `YOUR_SARVAM_API_KEY_HERE` with your actual key.
 
 5.  **Modify `merchant_context.md`:**
     Update the `merchant_context.md` file with any specific sales data, product combos, or other information relevant to the merchant.

--- a/examples/Indic Soundbox AI/modules/asr.py
+++ b/examples/Indic Soundbox AI/modules/asr.py
@@ -15,7 +15,7 @@ def speech_to_text(audio_blob):
 
     files = {'file': ('input.wav', audio_blob, 'audio/wav')}
     data = {
-        'model': 'saarika:v2.5',
+        'model': 'saaras:v3',
         'language_code': 'unknown'
     }
     headers = {'api-subscription-key': SARVAM_API_KEY}

--- a/examples/Indic Soundbox AI/modules/asr.py
+++ b/examples/Indic Soundbox AI/modules/asr.py
@@ -15,7 +15,7 @@ def speech_to_text(audio_blob):
 
     files = {'file': ('input.wav', audio_blob, 'audio/wav')}
     data = {
-        'model': 'saarika:v2',
+        'model': 'saarika:v2.5',
         'language_code': 'unknown'
     }
     headers = {'api-subscription-key': SARVAM_API_KEY}

--- a/examples/Indic Soundbox AI/modules/llm.py
+++ b/examples/Indic Soundbox AI/modules/llm.py
@@ -112,7 +112,8 @@ WhatsApp और Facebook पर अपनी दुकान की जानक
         'Content-Type': 'application/json'
     }
     payload = {
-        'model': 'sarvam-m',
+        'model': 'sarvam-105b',
+        'max_tokens': 2000,
         'messages': [
             {'role': 'system', 'content': system_prompt},
             {'role': 'user', 'content': user_text}

--- a/examples/Indic Soundbox AI/static/js/main.js
+++ b/examples/Indic Soundbox AI/static/js/main.js
@@ -286,7 +286,7 @@ async function processAudioPipeline() {
             console.warn("LID failed or no lang_code, using default");
         }
         console.log("Pipeline: Lang info:", langInfo);
-        const langCodeForTTS = lidResult && lidResult.language_code ? lidResult.language_code : 'hi';
+        const langCodeForTTS = lidResult && lidResult.language_code ? lidResult.language_code : 'hi-IN';
 
         setStatus('Thinking (LLM)...');
         botText = await sendChat(asrText || "(No speech detected)"); 
@@ -380,7 +380,7 @@ async function sendLID(text) {
     } catch (error) {
         console.error("sendLID Error:", error);
         // Return a default or null to allow pipeline to continue if LID is not critical
-        return { language_code: 'hi', script_code: 'Deva' }; 
+        return { language_code: 'hi-IN', script_code: 'Deva' };
     }
 }
 


### PR DESCRIPTION
Updates the **Indic Soundbox AI** example so it runs against the current Sarvam API, plus a small security/robustness cleanup.

## Changes
- **ASR** (`modules/asr.py`): `saarika:v2` → `saarika:v2.5` (current model for `/speech-to-text`).
- **Chat** (`modules/llm.py`): deprecated `sarvam-m` → `sarvam-105b` (flagship), and add `max_tokens` so longer replies aren't truncated.
- **TTS language fallback** (`static/js/main.js`): Sarvam TTS expects BCP-47 codes like `hi-IN`; a bare `'hi'` is rejected. Fixed the fallback on both the LID-failure path and the in-pipeline default (`'hi'` → `'hi-IN'`).
- **README**: removed a leaked example API key, fixed a reversed markdown link, and corrected the model name (Sarvam-M → Sarvam-105B).

## Testing
- `python -m py_compile` passes on `app.py` and all `modules/*.py`.
- Verified endpoints/models against current Sarvam docs (`/text-lid` returns `language_code` in `hi-IN` form; `saarika:v2.5`, `sarvam-105b`, `bulbul:v3` are current).

🤖 Generated with [Claude Code](https://claude.com/claude-code)