### PR TITLE
Fix Song_Lyrics_Generator: update ASR model to saarika:v2.5

### DIFF
--- a/examples/stt/Song_Lyrics_Generator.ipynb
+++ b/examples/stt/Song_Lyrics_Generator.ipynb
@@ -117,7 +117,7 @@
         "    }\n",
         "    data = {\n",
         "        \"language_code\": language_code,\n",
-        "        \"model\": \"saarika:v2.5\",\n",
+        "        \"model\": \"saaras:v3\",\n",
         "        \"with_timestamps\": \"false\"\n",
         "    }\n",
         "\n",

--- a/examples/stt/Song_Lyrics_Generator.ipynb
+++ b/examples/stt/Song_Lyrics_Generator.ipynb
@@ -117,7 +117,7 @@
         "    }\n",
         "    data = {\n",
         "        \"language_code\": language_code,\n",
-        "        \"model\": \"saarika:v2\",\n",
+        "        \"model\": \"saarika:v2.5\",\n",
         "        \"with_timestamps\": \"false\"\n",
         "    }\n",
         "\n",


### PR DESCRIPTION
## What

Updates the Speech-to-Text model in `examples/stt/Song_Lyrics_Generator.ipynb` from the superseded `saarika:v2` to the current **`saarika:v2.5`**.

## Why

`saarika:v2.5` is the current Saarika ASR model on the `/speech-to-text` endpoint. The example otherwise ran unchanged — this is a one-line model bump; the request shape and `transcript` response parsing are identical.

## Change

```diff
-        "model": "saarika:v2",
+        "model": "saarika:v2.5",
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)