### PR TITLE
Fix Subtitles: migrate to saaras:v3 on the /speech-to-text endpoint

### DIFF
--- a/examples/stt-translate/Subtitles.ipynb
+++ b/examples/stt-translate/Subtitles.ipynb
@@ -408,12 +408,12 @@
       },
       "outputs": [],
       "source": [
-        "api_url = \"https://api.sarvam.ai/speech-to-text-translate\"\n",
+        "api_url = \"https://api.sarvam.ai/speech-to-text\"\n",
         "headers = {\n",
         "    \"api-subscription-key\" :SARVAM_AI_API\n",
         "}\n",
         "data = {\n",
-        "    \"model\": \"saaras:v2\",\n",
+        "    \"model\": \"saaras:v3\",\n    \"mode\": \"translate\",\n",
         "}\n",
         "audio_file_path = \"\"\n"
       ]


### PR DESCRIPTION
## What

Migrates `examples/stt-translate/Subtitles.ipynb` from the deprecating `saaras:v2` (on `/speech-to-text-translate`) to the current **`saaras:v3`** on the unified `/speech-to-text` endpoint.

## Why

Sarvam is consolidating speech translation onto `/speech-to-text`: `saaras:v3` is the current recommended model and selects translation via the `mode` parameter, while `saaras:v2`/`v2.5` on the legacy `/speech-to-text-translate` endpoint is slated for deprecation.

## Change

```diff
-api_url = "https://api.sarvam.ai/speech-to-text-translate"
+api_url = "https://api.sarvam.ai/speech-to-text"
 data = {
-    "model": "saaras:v2",
+    "model": "saaras:v3",
+    "mode": "translate",
 }
```

The endpoint still returns `transcript`, so the VAD segmentation and SRT-writing logic downstream is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)