### PR TITLE
Fix converting_wav_into_mp3: correct Notes and document ffmpeg

### DIFF
--- a/examples/converting_wav_into_mp3/wav_to_mp3.ipynb
+++ b/examples/converting_wav_into_mp3/wav_to_mp3.ipynb
@@ -64,7 +64,12 @@
         }
       ],
       "source": [
-        "!pip install pydub"
+        "!pip install pydub\n",
+        "\n",
+        "# pydub uses ffmpeg under the hood for MP3 export.\n",
+        "# Google Colab / Debian Linux: uncomment the next line to install it.\n",
+        "# !apt-get -qq install -y ffmpeg\n",
+        "# macOS: `brew install ffmpeg`   |   Windows: download from ffmpeg.org and add it to PATH."
       ]
     },
     {
@@ -81,8 +86,8 @@
       "source": [
         "from pydub import AudioSegment\n",
         "\n",
-        "# Load the .wav file\n",
-        "wav_file = AudioSegment.from_wav(\"output0.wav\")\n",
+        "# Load the .wav file (replace with the path to your own .wav file)\n",
+        "wav_file = AudioSegment.from_wav(\"input.wav\")\n",
         "\n",
         "# Export the file as .mp3\n",
         "wav_file.export(\"output_file.mp3\", format=\"mp3\")\n",
@@ -114,18 +119,19 @@
         "\n",
         "### **Additional Resources**\n",
         "\n",
-        "For more details, refer to the official **Sarvam AI API documentation** and join the community for support:\n",
+        "For more on `pydub`, see its docs; for Sarvam AI, join the community for support:\n",
         "\n",
-        "- **Documentation**: [docs.sarvam.ai](https://docs.sarvam.ai/)\n",
+        "- **pydub**: [github.com/jiaaro/pydub](https://github.com/jiaaro/pydub)\n",
+        "- **Sarvam Docs**: [docs.sarvam.ai](https://docs.sarvam.ai/)\n",
         "- **Community**: [Join the Discord Community](https://discord.gg/hTuVuPNF)\n",
         "\n",
         "### **Notes:**\n",
         "\n",
-        "**File Format:** Ensure the file is in .wav format and has a sample rate of 16kHz.\n",
+        "**Input Format:** Ensure the input is a valid `.wav` file.\n",
         "\n",
-        "**API Key:** Double-check that the SARVAM_API_KEY is correctly set.\n",
+        "**ffmpeg Required:** `pydub` shells out to `ffmpeg` for MP3 export — make sure `ffmpeg` is installed and on your system PATH, otherwise the export step will fail.\n",
         "\n",
-        "**Error Handling:** If transcription fails, the error message and response content will be displayed for debugging.\n",
+        "**Output:** The converted audio is written to `output_file.mp3` in the working directory.\n",
         "\n",
         "**Keep Building!** 🚀\n"
       ],


### PR DESCRIPTION
## What

Cleanup for `examples/converting_wav_into_mp3/wav_to_mp3.ipynb`. This notebook is a pure `pydub` WAV→MP3 utility — it makes **no Sarvam API calls** — but its footer was copy-pasted from an STT example and its `ffmpeg` dependency was undocumented.

## Changes

- **Notes:** removed the boilerplate that referenced *transcription* and `SARVAM_API_KEY` (neither applies here). Documented the real requirements instead: valid `.wav` input, the `ffmpeg` dependency, and the output location.
- **Install cell:** added `ffmpeg` install guidance — `pydub`'s MP3 export shells out to `ffmpeg`, so `pip install pydub` alone isn't enough. Covers Colab/Debian, macOS, and Windows.
- **Conversion cell:** renamed the placeholder input `output0.wav` → `input.wav` and noted it's user-supplied (the old name didn't exist and was confusing).

No functional/API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)