### PR TITLE
Fix book__summary_narrator: replace Gemini with Sarvam Chat, use SDK

### DIFF
--- a/examples/tts/book__summary_narrator.ipynb
+++ b/examples/tts/book__summary_narrator.ipynb
@@ -70,64 +70,10 @@
       },
       "source": [
         "!pip install PyPDF2\n",
-        "!pip install google-generativeai\n",
-        "!pip install requests\n",
-        "!pip install textwrap3\n",
-        "!pip install pathlib"
+        "!pip install sarvamai"
       ],
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Collecting PyPDF2\n",
-            "  Downloading pypdf2-3.0.1-py3-none-any.whl.metadata (6.8 kB)\n",
-            "Downloading pypdf2-3.0.1-py3-none-any.whl (232 kB)\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m232.6/232.6 kB\u001b[0m \u001b[31m2.4 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hInstalling collected packages: PyPDF2\n",
-            "Successfully installed PyPDF2-3.0.1\n",
-            "Requirement already satisfied: google-generativeai in /usr/local/lib/python3.11/dist-packages (0.8.3)\n",
-            "Requirement already satisfied: google-ai-generativelanguage==0.6.10 in /usr/local/lib/python3.11/dist-packages (from google-generativeai) (0.6.10)\n",
-            "Requirement already satisfied: google-api-core in /usr/local/lib/python3.11/dist-packages (from google-generativeai) (2.19.2)\n",
-            "Requirement already satisfied: google-api-python-client in /usr/local/lib/python3.11/dist-packages (from google-generativeai) (2.155.0)\n",
-            "Requirement already satisfied: google-auth>=2.15.0 in /usr/local/lib/python3.11/dist-packages (from google-generativeai) (2.27.0)\n",
-            "Requirement already satisfied: protobuf in /usr/local/lib/python3.11/dist-packages (from google-generativeai) (4.25.5)\n",
-            "Requirement already satisfied: pydantic in /usr/local/lib/python3.11/dist-packages (from google-generativeai) (2.10.5)\n",
-            "Requirement already satisfied: tqdm in /usr/local/lib/python3.11/dist-packages (from google-generativeai) (4.67.1)\n",
-            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.11/dist-packages (from google-generativeai) (4.12.2)\n",
-            "Requirement already satisfied: proto-plus<2.0.0dev,>=1.22.3 in /usr/local/lib/python3.11/dist-packages (from google-ai-generativelanguage==0.6.10->google-generativeai) (1.25.0)\n",
-            "Requirement already satisfied: googleapis-common-protos<2.0.dev0,>=1.56.2 in /usr/local/lib/python3.11/dist-packages (from google-api-core->google-generativeai) (1.66.0)\n",
-            "Requirement already satisfied: requests<3.0.0.dev0,>=2.18.0 in /usr/local/lib/python3.11/dist-packages (from google-api-core->google-generativeai) (2.32.3)\n",
-            "Requirement already satisfied: cachetools<6.0,>=2.0.0 in /usr/local/lib/python3.11/dist-packages (from google-auth>=2.15.0->google-generativeai) (5.5.0)\n",
-            "Requirement already satisfied: pyasn1-modules>=0.2.1 in /usr/local/lib/python3.11/dist-packages (from google-auth>=2.15.0->google-generativeai) (0.4.1)\n",
-            "Requirement already satisfied: rsa<5,>=3.1.4 in /usr/local/lib/python3.11/dist-packages (from google-auth>=2.15.0->google-generativeai) (4.9)\n",
-            "Requirement already satisfied: httplib2<1.dev0,>=0.19.0 in /usr/local/lib/python3.11/dist-packages (from google-api-python-client->google-generativeai) (0.22.0)\n",
-            "Requirement already satisfied: google-auth-httplib2<1.0.0,>=0.2.0 in /usr/local/lib/python3.11/dist-packages (from google-api-python-client->google-generativeai) (0.2.0)\n",
-            "Requirement already satisfied: uritemplate<5,>=3.0.1 in /usr/local/lib/python3.11/dist-packages (from google-api-python-client->google-generativeai) (4.1.1)\n",
-            "Requirement already satisfied: annotated-types>=0.6.0 in /usr/local/lib/python3.11/dist-packages (from pydantic->google-generativeai) (0.7.0)\n",
-            "Requirement already satisfied: pydantic-core==2.27.2 in /usr/local/lib/python3.11/dist-packages (from pydantic->google-generativeai) (2.27.2)\n",
-            "Requirement already satisfied: grpcio<2.0dev,>=1.33.2 in /usr/local/lib/python3.11/dist-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.1->google-ai-generativelanguage==0.6.10->google-generativeai) (1.69.0)\n",
-            "Requirement already satisfied: grpcio-status<2.0.dev0,>=1.33.2 in /usr/local/lib/python3.11/dist-packages (from google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.10.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,<3.0.0dev,>=1.34.1->google-ai-generativelanguage==0.6.10->google-generativeai) (1.62.3)\n",
-            "Requirement already satisfied: pyparsing!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3,<4,>=2.4.2 in /usr/local/lib/python3.11/dist-packages (from httplib2<1.dev0,>=0.19.0->google-api-python-client->google-generativeai) (3.2.1)\n",
-            "Requirement already satisfied: pyasn1<0.7.0,>=0.4.6 in /usr/local/lib/python3.11/dist-packages (from pyasn1-modules>=0.2.1->google-auth>=2.15.0->google-generativeai) (0.6.1)\n",
-            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.11/dist-packages (from requests<3.0.0.dev0,>=2.18.0->google-api-core->google-generativeai) (3.4.1)\n",
-            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.11/dist-packages (from requests<3.0.0.dev0,>=2.18.0->google-api-core->google-generativeai) (3.10)\n",
-            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.11/dist-packages (from requests<3.0.0.dev0,>=2.18.0->google-api-core->google-generativeai) (2.3.0)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.11/dist-packages (from requests<3.0.0.dev0,>=2.18.0->google-api-core->google-generativeai) (2024.12.14)\n",
-            "Requirement already satisfied: requests in /usr/local/lib/python3.11/dist-packages (2.32.3)\n",
-            "Requirement already satisfied: charset-normalizer<4,>=2 in /usr/local/lib/python3.11/dist-packages (from requests) (3.4.1)\n",
-            "Requirement already satisfied: idna<4,>=2.5 in /usr/local/lib/python3.11/dist-packages (from requests) (3.10)\n",
-            "Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/local/lib/python3.11/dist-packages (from requests) (2.3.0)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.11/dist-packages (from requests) (2024.12.14)\n",
-            "Collecting textwrap3\n",
-            "  Downloading textwrap3-0.9.2-py2.py3-none-any.whl.metadata (4.6 kB)\n",
-            "Downloading textwrap3-0.9.2-py2.py3-none-any.whl (12 kB)\n",
-            "Installing collected packages: textwrap3\n",
-            "Successfully installed textwrap3-0.9.2\n",
-            "Requirement already satisfied: pathlib in /usr/local/lib/python3.11/dist-packages (1.0.1)\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -147,14 +93,12 @@
       "source": [
         "import os\n",
         "import PyPDF2\n",
-        "import google.generativeai as genai\n",
-        "import requests\n",
         "import logging\n",
         "from pathlib import Path\n",
-        "import json\n",
-        "from textwrap import wrap\n",
         "import time\n",
-        "import base64\n"
+        "\n",
+        "from sarvamai import SarvamAI\n",
+        "from sarvamai.play import save"
       ],
       "execution_count": 2,
       "outputs": []
@@ -200,12 +144,12 @@
         "id": "h1Bi_61mx3mG"
       },
       "source": [
-        "# **Set Up the API Endpoint and Payload**\n",
+        "# **Set Up the API Key**\n",
         "\n",
-        "### To use the Saaras API, you need an API subscription key. Follow these steps to set up your API key:\n",
+        "### To use the Sarvam APIs, you need an API subscription key. Follow these steps to set up your API key:\n",
         "\n",
-        "### **1. Obtain your API key**: If you don’t have an API key, sign up on the Sarvam AI Dashboard to get one.\n",
-        "### **2. Replace the placeholder key:** In the code below, replace \"YOUR_SARVAM_AI_API_KEY\" and \"YOUR_GEMINI_API_KEY\" with your actual API key.\n"
+        "### **1. Obtain your API key**: If you don't have an API key, sign up on the Sarvam AI Dashboard to get one.\n",
+        "### **2. Replace the placeholder key:** In the code below, replace \"YOUR_SARVAM_AI_API_KEY\" with your actual API key."
       ]
     },
     {
@@ -214,10 +158,11 @@
         "id": "USFy2lQMx7I9"
       },
       "source": [
-        "\n",
         "SARVAM_API_KEY = \"YOUR_SARVAM_AI_API_KEY\"\n",
-        "GEMINI_API_KEY = \"YOUR_GEMINI_API_KEY\"\n",
-        "MAX_CHUNK_LENGTH = 500  # Maximum characters per chunk for Text-to-Speech (TTS)"
+        "MAX_CHUNK_LENGTH = 500  # Maximum characters per chunk for Text-to-Speech (TTS)\n",
+        "\n",
+        "# One client is reused for both summarization (Chat) and narration (TTS)\n",
+        "client = SarvamAI(api_subscription_key=SARVAM_API_KEY)"
       ],
       "execution_count": 4,
       "outputs": []
@@ -261,9 +206,8 @@
         "id": "fMN31ECqyQ2t"
       },
       "source": [
-        "# **Generate Summary Using** *Gemini API*\n",
-        "### Function to generate a concise summary of text using the Gemini API.\n",
-        "\n"
+        "# **Generate Summary Using** *Sarvam Chat API*\n",
+        "### Function to generate a concise summary of text using the Sarvam Chat Completion API (`sarvam-105b`).\n"
       ]
     },
     {
@@ -273,18 +217,25 @@
       },
       "source": [
         "def generate_summary(text):\n",
-        "    \"\"\"Generate summary using Google's Gemini API.\"\"\"\n",
+        "    \"\"\"Generate a summary using Sarvam's Chat Completion API (sarvam-105b).\"\"\"\n",
         "    try:\n",
-        "        genai.configure(api_key=GEMINI_API_KEY)\n",
-        "        model = genai.GenerativeModel('gemini-pro')\n",
-        "        prompt = f\"\"\"Please provide a concise summary of the following text. Focus on the main ideas \\\n",
-        "        and key points, keeping the summary clear and engaging: {text}\"\"\"\n",
-        "        response = model.generate_content(prompt)\n",
-        "        logging.info(\"Successfully generated summary using Gemini API\")\n",
-        "        return response.text\n",
+        "        prompt = (\n",
+        "            \"Please provide a concise summary of the following text. \"\n",
+        "            \"Focus on the main ideas and key points, keeping the summary \"\n",
+        "            \"clear and engaging: \" + text\n",
+        "        )\n",
+        "        response = client.chat.completions(\n",
+        "            model=\"sarvam-105b\",\n",
+        "            messages=[{\"role\": \"user\", \"content\": prompt}],\n",
+        "            temperature=0.3,\n",
+        "            max_tokens=2000,\n",
+        "        )\n",
+        "        summary = response.choices[0].message.content\n",
+        "        logging.info(\"Successfully generated summary using Sarvam Chat API\")\n",
+        "        return summary\n",
         "    except Exception as e:\n",
         "        logging.error(f\"Error generating summary: {str(e)}\")\n",
-        "        raise\n"
+        "        raise"
       ],
       "execution_count": 6,
       "outputs": []
@@ -355,47 +306,18 @@
       },
       "source": [
         "def text_to_speech(text, output_path, language_code=\"en-IN\"):\n",
-        "    \"\"\"Convert text to speech using Sarvam AI API.\"\"\"\n",
-        "    url = \"https://api.sarvam.ai/text-to-speech\"\n",
-        "\n",
-        "    payload = {\n",
-        "        \"inputs\": [text],\n",
-        "        \"target_language_code\": language_code,\n",
-        "        \"speaker\": \"shubh\",\n",
-        "        \"pace\": 1.0,\n",
-        "        \"temperature\": 0.6,\n",
-        "        \"speech_sample_rate\": 22050,\n",
-        "        \"model\": \"bulbul:v3\"\n",
-        "    }\n",
-        "\n",
-        "    headers = {\n",
-        "        \"Accept\": \"application/json\",\n",
-        "        \"Content-Type\": \"application/json\",\n",
-        "        \"api-subscription-key\": SARVAM_API_KEY\n",
-        "    }\n",
-        "\n",
+        "    \"\"\"Convert text to speech using Sarvam's Text-to-Speech API (bulbul:v3).\"\"\"\n",
         "    try:\n",
-        "        logging.info(f\"Sending request to Sarvam API for chunk of length {len(text)}\")\n",
-        "        response = requests.post(url, json=payload, headers=headers)\n",
-        "\n",
-        "        logging.info(f\"Sarvam API Response Status Code: {response.status_code}\")\n",
-        "\n",
-        "        response.raise_for_status()\n",
-        "\n",
-        "        audio_data = response.json()\n",
-        "\n",
-        "        if \"audios\" in audio_data:\n",
-        "            base64_audio = audio_data[\"audios\"][0]\n",
-        "            binary_audio = base64.b64decode(base64_audio)\n",
-        "\n",
-        "            with open(output_path, 'wb') as f:\n",
-        "                f.write(binary_audio)\n",
-        "            logging.info(f\"Successfully saved audio file to {output_path}\")\n",
-        "            return True\n",
-        "        else:\n",
-        "            logging.error(\"No audio data found in response.\")\n",
-        "            return False\n",
-        "\n",
+        "        logging.info(f\"Sending text of length {len(text)} to Sarvam TTS\")\n",
+        "        response = client.text_to_speech.convert(\n",
+        "            text=text,\n",
+        "            target_language_code=language_code,\n",
+        "            speaker=\"shubh\",\n",
+        "            model=\"bulbul:v3\",\n",
+        "        )\n",
+        "        save(response, output_path)\n",
+        "        logging.info(f\"Successfully saved audio file to {output_path}\")\n",
+        "        return True\n",
         "    except Exception as e:\n",
         "        logging.error(f\"Error converting text to speech: {str(e)}\")\n",
         "        raise"
@@ -514,11 +436,11 @@
         "\n",
         "### **Notes:**\n",
         "\n",
-        "**File Format:** Ensure the file is in .wav format and has a sample rate of 16kHz.\n",
+        "**PDF Input:** Provide a text-based PDF; scanned/image-only PDFs won't yield extractable text.\n",
         "\n",
-        "**API Key:** Double-check that the SARVAM_API_KEY is correctly set.\n",
+        "**API Key:** Double-check that `SARVAM_API_KEY` is set correctly.\n",
         "\n",
-        "**Error Handling:** If transcription fails, the error message and response content will be displayed for debugging.\n",
+        "**Output:** The extracted text, summary, and per-chunk narration `.wav` files are written to the `output/` directory.\n",
         "\n",
         "**Keep Building!** 🚀\n"
       ]


### PR DESCRIPTION
## What

Makes `examples/tts/book__summary_narrator.ipynb` a pure-Sarvam, single-key example. The summary step previously called **Google Gemini `gemini-pro`** (a retired model needing a separate Google API key) inside a Sarvam cookbook. It now uses Sarvam's own **Chat Completions (`sarvam-105b`)**, and TTS is migrated to the Sarvam SDK.

## Why

- `gemini-pro` is retired, so the example was broken as shipped.
- Requiring a second (Google) API key in a Sarvam cookbook is off-brand and adds friction.
- The TTS payload sent a `temperature` field that `bulbul:v3` doesn't accept.

## Changes

- **Summary:** `google.generativeai` / `gemini-pro` → `client.chat.completions(model="sarvam-105b", …, max_tokens=2000)` via the `sarvamai` SDK.
- **TTS:** raw `requests` + manual base64 → `client.text_to_speech.convert(...)` + `save(...)`; dropped the unsupported `temperature` param (`bulbul:v3` was kept, `shubh` speaker is valid).
- **Deps:** dropped `google-generativeai`, `requests`, `textwrap3`, and the harmful `pip install pathlib` (pathlib is stdlib); added `sarvamai`.
- **Config:** removed `GEMINI_API_KEY`; one reused `SarvamAI` client.
- **Notes:** replaced the copy-pasted transcription/16kHz boilerplate with PDF-input and output-location guidance.

## Verification

Ran the rewritten functions against the live API: `sarvam-105b` returns a correct summary of sample text, and `bulbul:v3` (via `client.text_to_speech.convert` + `save`) writes a valid narration `.wav`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)