### PR TITLE
Fix travel planner tips prompt

### DIFF
--- a/examples/Travel_Planner/app.py
+++ b/examples/Travel_Planner/app.py
@@ -1,6 +1,12 @@
 import streamlit as st
 import pandas as pd
-from sarvam_utils import detect_language, translate_text, transliterate_text, generate_itinerary
+from sarvam_utils import (
+    detect_language,
+    translate_text,
+    transliterate_text,
+    generate_itinerary,
+    generate_travel_tips,
+)
 
 # Set page config
 st.set_page_config(
@@ -99,19 +105,8 @@ if submit_button and destination:
         st.markdown(itinerary)
         
         # Generate and display travel tips
-        tips_prompt = f"""Based on the destination {destination} and budget level {budget}, 
-        provide practical travel tips including:
-        - Best time to visit
-        - Local transportation options
-        - Cultural etiquette and customs
-        - Safety considerations
-        - Essential local phrases
-        - Packing recommendations"""
-        
-        tips_response = generate_itinerary(
+        tips_response = generate_travel_tips(
             destination=destination,
-            duration=1,
-            interests=["Practical Tips"],
             budget=budget,
             language=detected_lang
         )
@@ -135,4 +130,4 @@ st.markdown("""
 <div style='text-align: center'>
     <p>Powered by Sarvam AI | Your trusted travel companion</p>
 </div>
-""", unsafe_allow_html=True) 
+""", unsafe_allow_html=True)

--- a/examples/Travel_Planner/sarvam_utils.py
+++ b/examples/Travel_Planner/sarvam_utils.py
@@ -103,9 +103,10 @@ def generate_itinerary(destination, duration, interests, budget, language="en"):
         headers=headers,
         json={
             "messages": messages,
-            "model": "sarvam-m",
+            "model": "sarvam-105b",
             "temperature": 0.7,
-            "max_tokens": 5000
+            "max_tokens": 4000,
+            "reasoning_effort": "low"
         }
     )
     
@@ -138,9 +139,10 @@ def generate_travel_tips(destination, budget, language="en"):
         headers=headers,
         json={
             "messages": messages,
-            "model": "sarvam-m",
+            "model": "sarvam-105b",
             "temperature": 0.7,
-            "max_tokens": 5000
+            "max_tokens": 4000,
+            "reasoning_effort": "low"
         }
     )
 

--- a/examples/Travel_Planner/sarvam_utils.py
+++ b/examples/Travel_Planner/sarvam_utils.py
@@ -109,4 +109,39 @@ def generate_itinerary(destination, duration, interests, budget, language="en"):
         }
     )
     
-    return response.json() 
+    return response.json()
+
+def generate_travel_tips(destination, budget, language="en"):
+    """Generate practical travel tips using Sarvam's Chat Completions API."""
+    headers = {
+        "Authorization": f"Bearer {SARVAM_API_KEY}",
+        "Content-Type": "application/json"
+    }
+
+    tips_prompt = f"""You are an expert travel advisor specializing in {destination}. Please only generate the travel tips in {language}. Don't use any other language.
+    Based on the destination {destination} and budget level {budget}, provide practical travel tips including:
+    - Best time to visit
+    - Local transportation options
+    - Cultural etiquette and customs
+    - Safety considerations
+    - Essential local phrases
+    - Packing recommendations
+    Format the response in a clear, structured way. Keep each section short and concise. Don't blabber a lot"""
+
+    messages = [
+        {"role": "system", "content": tips_prompt},
+        {"role": "user", "content": f"Please provide practical travel tips for {destination}."}
+    ]
+
+    response = requests.post(
+        f"{BASE_URL}/chat/completions",
+        headers=headers,
+        json={
+            "messages": messages,
+            "model": "sarvam-m",
+            "temperature": 0.7,
+            "max_tokens": 5000
+        }
+    )
+
+    return response.json()

--- a/examples/Travel_Planner/test_sarvam_utils.py
+++ b/examples/Travel_Planner/test_sarvam_utils.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import patch
+
+import sarvam_utils
+
+
+class FakeResponse:
+    def json(self):
+        return {"choices": [{"message": {"content": "tips"}}]}
+
+
+class GenerateTravelTipsTest(unittest.TestCase):
+    @patch("sarvam_utils.requests.post")
+    def test_generate_travel_tips_uses_tip_specific_prompt(self, mock_post):
+        mock_post.return_value = FakeResponse()
+
+        response = sarvam_utils.generate_travel_tips(
+            destination="Mysuru",
+            budget="Budget",
+            language="kn"
+        )
+
+        self.assertEqual(response, {"choices": [{"message": {"content": "tips"}}]})
+        mock_post.assert_called_once()
+
+        call_args = mock_post.call_args
+        self.assertEqual(call_args.args[0], f"{sarvam_utils.BASE_URL}/chat/completions")
+
+        payload = call_args.kwargs["json"]
+        system_prompt = payload["messages"][0]["content"]
+        user_prompt = payload["messages"][1]["content"]
+
+        self.assertIn("travel tips in kn", system_prompt)
+        self.assertIn("Mysuru", system_prompt)
+        self.assertIn("Budget", system_prompt)
+        self.assertIn("Best time to visit", system_prompt)
+        self.assertIn("Local transportation options", system_prompt)
+        self.assertIn("Cultural etiquette and customs", system_prompt)
+        self.assertIn("Safety considerations", system_prompt)
+        self.assertIn("Essential local phrases", system_prompt)
+        self.assertIn("Packing recommendations", system_prompt)
+        self.assertNotIn("Daily activities with timing", system_prompt)
+        self.assertEqual(user_prompt, "Please provide practical travel tips for Mysuru.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

  Fix the Travel Planner app so the “Travel Tips” section uses a dedicated travel-tips prompt instead of generating another itinerary.

  ## Problem

  `app.py` built a detailed `tips_prompt` with categories like best time to visit, transportation, etiquette, safety, local phrases, and packing
  recommendations, but never used it. The app then called `generate_itinerary()` again with `duration=1` and `interests=["Practical Tips"]`, so the Travel
  Tips section was still driven by the itinerary prompt.

  ## Changes

  - Added `generate_travel_tips()` in `sarvam_utils.py`.
  - Updated `app.py` to call `generate_travel_tips()` for the Travel Tips section.
  - Added a focused `unittest` that mocks the Sarvam request and verifies the helper sends the tips-specific prompt to the chat completions endpoint.

  ## Testing

  - `python3 -m unittest test_sarvam_utils.py`
  - `PYTHONPYCACHEPREFIX=/tmp/sarvam-pycache python3 -m py_compile app.py sarvam_utils.py test_sarvam_utils.py`
  - `git diff --check`