### PR TITLE
Added Realtime Voice Agent in example/

### DIFF
--- a/examples/Realtime_Voice_Agent/.env.example
+++ b/examples/Realtime_Voice_Agent/.env.example
@@ -1,0 +1,9 @@
+# Get your key from https://dashboard.sarvam.ai/
+SARVAM_API_KEY=your_sarvam_api_key_here
+
+# Conversation language, used for both STT input and TTS output.
+# One of: bn-IN, en-IN, gu-IN, hi-IN, kn-IN, ml-IN, mr-IN, od-IN, pa-IN, ta-IN, te-IN
+LANGUAGE=hi-IN
+
+# TTS voice: anushka, manisha, vidya, arya (female) / abhilash, karun, hitesh (male)
+SPEAKER=anushka

--- a/examples/Realtime_Voice_Agent/.gitignore
+++ b/examples/Realtime_Voice_Agent/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/examples/Realtime_Voice_Agent/README.md
+++ b/examples/Realtime_Voice_Agent/README.md
@@ -1,0 +1,73 @@
+# Realtime Voice Agent
+
+A speech-to-speech voice agent built on Sarvam's WebSocket APIs. You talk, it talks back — and you can cut it off mid-sentence.
+
+<div align="center">
+
+https://github.com/user-attachments/assets/5e939abd-1e86-4d83-a5ef-7ad02f168811
+
+</div>
+```
+browser mic ──PCM──▶ FastAPI ──▶ STT streaming WS (saaras:v3)
+                        │                │ transcript
+                        │                ▼
+                        │         Chat Completion (sarvam-105b, streamed)
+                        │                │ sentences
+                        │                ▼
+browser speaker ◀─PCM── └────────  TTS streaming WS (bulbul:v2)
+```
+
+Everything is streamed end to end: the assistant starts speaking the first sentence while the model is still writing the second one.
+
+> **Latency, honestly.** Both Sarvam chat models are reasoning models, and the thinking is not optional (`reasoning_effort="none"` is rejected). The model typically spends ~1000 reasoning tokens before its first real word, so expect **roughly 5–8 seconds from end of speech to first audio**. The STT and TTS legs are genuinely realtime; the LLM is the bottleneck. This is a property of the models available today, not of the pipeline.
+
+## Features
+
+- **Streaming STT** over `speech-to-text/ws`, so transcripts finalize as you pause instead of after you stop.
+- **Barge-in.** STT emits a `START_SPEECH` VAD signal the moment you talk over the assistant. That cancels the in-flight turn, closes its TTS socket, and clears the browser's playback queue.
+- **Sentence-level TTS.** LLM tokens are buffered only until a sentence ends (including the Devanagari danda `।`), then pushed straight into the TTS socket.
+- **No audio dependencies.** TTS is requested as `linear16`, so the browser plays raw PCM through the Web Audio API — no ffmpeg, no pydub.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+cp .env.example .env      # then add your key from https://dashboard.sarvam.ai/
+python app.py
+```
+
+Open http://127.0.0.1:8000, click **Start talking**, and allow mic access.
+
+> Chrome and Edge only give you a mic on `localhost` or HTTPS. If you host this anywhere else, put it behind TLS.
+
+## Configuration
+
+Set these in `.env`:
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `SARVAM_API_KEY` | — | Required. |
+| `LANGUAGE` | `hi-IN` | Used for both STT input and TTS output. One of `bn-IN`, `en-IN`, `gu-IN`, `hi-IN`, `kn-IN`, `ml-IN`, `mr-IN`, `od-IN`, `pa-IN`, `ta-IN`, `te-IN`. |
+| `SPEAKER` | `anushka` | `anushka`, `manisha`, `vidya`, `arya` (female); `abhilash`, `karun`, `hitesh` (male). |
+
+The agent's personality lives in `SYSTEM_PROMPT` in `app.py`. It tells the model to answer in one or two sentences, because long replies feel slow when they're read aloud.
+
+STT can auto-detect the language (`language_code="unknown"`), but TTS needs a concrete one, so this example fixes a single language per session.
+
+### Why `sarvam-105b` and not `sarvam-30b`
+
+`sarvam-m` is deprecated; the API now offers only `sarvam-30b` and `sarvam-105b`. Both reason before answering. In testing, **`sarvam-30b` regularly spent its entire token budget reasoning and never emitted an answer at all** — so this example uses `sarvam-105b` with `reasoning_effort="low"` (measurably faster to first word than the default) and a `max_tokens` large enough to cover the thinking *plus* the reply. If you lower `MAX_TOKENS`, the model may think until it runs out and say nothing.
+
+## How it works
+
+`app.py` holds one STT socket open for the whole session and opens a **fresh TTS socket per assistant turn**. That's what makes interruption clean: cancelling the turn task closes its TTS socket, so no stale audio from the abandoned reply can arrive after the user has moved on.
+
+Audio flows as raw PCM in both directions — 16 kHz mono up from the mic (`input_audio_codec="pcm_s16le"`), 22.05 kHz back down from TTS. The browser schedules each chunk on a playback cursor so they play gapless, and drops the cursor on interrupt.
+
+Run `python test_app.py` to check the sentence splitter that decides when to hand text to TTS.
+
+## Known limits
+
+- An interrupted reply is dropped from the history rather than truncated at the last word the user actually heard. Track played audio if that matters for your use case.
+- Mic capture uses `ScriptProcessorNode` (deprecated, but needs no worklet file). Move to an `AudioWorklet` if the main thread stutters.
+- Conversation history grows without bound. Add a window or summary for long sessions.

--- a/examples/Realtime_Voice_Agent/app.py
+++ b/examples/Realtime_Voice_Agent/app.py
@@ -1,0 +1,211 @@
+"""Realtime voice agent: mic -> STT (websocket) -> Chat Completion -> TTS (websocket) -> speaker.
+
+The browser streams raw PCM to this server, which relays it to Sarvam's streaming
+STT socket. Each finalized transcript starts an assistant turn: chat completions are
+streamed token by token, complete sentences are pushed into a streaming TTS socket,
+and the synthesized audio is sent straight back to the browser.
+
+Barge-in: STT emits a START_SPEECH VAD signal as soon as the user talks over the
+assistant, which cancels the in-flight turn and clears the browser's playback queue.
+"""
+
+import asyncio
+import base64
+import math
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import FileResponse
+from sarvamai import AsyncSarvamAI
+
+load_dotenv()
+
+API_KEY = os.getenv("SARVAM_API_KEY")
+if not API_KEY:
+    raise SystemExit("SARVAM_API_KEY is not set. Copy .env.example to .env first.")
+
+LANGUAGE = os.getenv("LANGUAGE", "hi-IN")  # STT input and TTS output language
+SPEAKER = os.getenv("SPEAKER", "anushka")
+# Both Sarvam chat models "think" before answering, and the thinking is not optional
+# (reasoning_effort="none" is rejected). sarvam-30b routinely spends its whole token
+# budget reasoning and never emits an answer, so 105b on low effort is the only usable
+# pairing for voice. max_tokens must cover reasoning AND the reply.
+CHAT_MODEL = "sarvam-105b"
+REASONING_EFFORT = "low"
+MAX_TOKENS = 2048
+MIC_SAMPLE_RATE = 16000
+TTS_SAMPLE_RATE = 22050
+# End-of-utterance detection. The browser sends ~128ms per frame, so 6 quiet frames
+# is roughly three quarters of a second of silence before we finalize the transcript.
+SPEECH_RMS = 500  # int16 RMS above which a frame counts as speech
+SILENCE_FRAMES_TO_FLUSH = 6
+SYSTEM_PROMPT = (
+    "You are a friendly voice assistant for Indian users. You are being spoken to, "
+    "and your reply is read aloud, so keep answers to one or two short sentences. "
+    "Reply in the same language the user speaks. Never use markdown or emoji."
+)
+
+app = FastAPI()
+client = AsyncSarvamAI(api_subscription_key=API_KEY)
+
+# Sentence enders, including the Devanagari danda, so TTS gets natural chunks.
+SENTENCE_END = re.compile(r"(?<=[.!?।॥])\s+")
+
+
+def split_sentences(buffer: str) -> tuple[list[str], str]:
+    """Split a partial LLM stream into complete sentences plus the unfinished remainder."""
+    *sentences, remainder = SENTENCE_END.split(buffer)
+    return [s for s in sentences if s.strip()], remainder
+
+
+@app.get("/")
+async def index():
+    return FileResponse(Path(__file__).parent / "static" / "index.html")
+
+
+async def forward_audio(tts, browser: WebSocket) -> None:
+    """Send synthesized audio chunks to the browser until the turn's final event."""
+    while True:
+        message = await tts.recv()
+        if message.type == "audio":
+            await browser.send_json({"type": "audio", "audio": message.data.audio})
+        elif message.type == "event" and message.data.event_type == "final":
+            return
+        elif message.type == "error":
+            await browser.send_json({"type": "error", "text": str(message.data)})
+            return
+
+
+async def speak_turn(browser: WebSocket, history: list[Any]) -> None:
+    """Stream one assistant turn. Cancelling this task ends the turn and closes its TTS socket."""
+    reply = ""
+    async with client.text_to_speech_streaming.connect(
+        model="bulbul:v2", send_completion_event="true"
+    ) as tts:
+        await tts.configure(
+            target_language_code=LANGUAGE,
+            speaker=SPEAKER,
+            output_audio_codec="linear16",  # raw PCM: the browser plays it without a decoder
+            speech_sample_rate=TTS_SAMPLE_RATE,
+            enable_preprocessing=True,
+        )
+        forwarder = asyncio.create_task(forward_audio(tts, browser))
+
+        buffer = ""
+        stream = await client.chat.completions(
+            messages=history,
+            model=CHAT_MODEL,
+            stream=True,
+            reasoning_effort=REASONING_EFFORT,
+            max_tokens=MAX_TOKENS,
+        )
+        async for chunk in stream:
+            # The final usage chunk carries no choices, and reasoning chunks put their
+            # tokens in delta.reasoning_content — neither is speakable.
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta.content or ""
+            if not delta:
+                continue
+            reply += delta
+            buffer += delta
+            await browser.send_json({"type": "assistant_delta", "text": delta})
+
+            sentences, buffer = split_sentences(buffer)
+            for sentence in sentences:
+                await tts.convert(sentence)
+
+        if buffer.strip():
+            await tts.convert(buffer.strip())
+        await tts.flush()
+        await forwarder
+
+    history.append({"role": "assistant", "content": reply})
+
+
+@app.websocket("/ws")
+async def voice_agent(browser: WebSocket) -> None:
+    await browser.accept()
+    history: list[Any] = [{"role": "system", "content": SYSTEM_PROMPT}]
+    turn: asyncio.Task | None = None
+
+    async with client.speech_to_text_streaming.connect(
+        language_code=LANGUAGE,
+        model="saaras:v3",
+        mode="transcribe",
+        sample_rate=str(MIC_SAMPLE_RATE),
+        input_audio_codec="pcm_s16le",
+        vad_signals="true",  # needed for barge-in
+    ) as stt:
+
+        async def pump_mic() -> None:
+            # Streaming STT only finalizes a transcript when it is flushed — the VAD
+            # END_SPEECH signal follows the flush, it does not cause one. So watch the
+            # mic level and flush once the user has gone quiet.
+            # ponytail: plain RMS gate. Swap in a real VAD if the room is noisy.
+            speaking = False
+            quiet_frames = 0
+            while True:
+                pcm = await browser.receive_bytes()
+                await stt.transcribe(
+                    audio=base64.b64encode(pcm).decode(), sample_rate=MIC_SAMPLE_RATE
+                )
+
+                samples = memoryview(pcm).cast("h")
+                if not samples:
+                    continue
+                rms = math.sqrt(sum(s * s for s in samples) / len(samples))
+
+                if rms > SPEECH_RMS:
+                    speaking = True
+                    quiet_frames = 0
+                elif speaking:
+                    quiet_frames += 1
+                    if quiet_frames >= SILENCE_FRAMES_TO_FLUSH:
+                        await stt.flush()  # finalize; the transcript arrives next
+                        speaking = False
+                        quiet_frames = 0
+
+        async def handle_transcripts() -> None:
+            nonlocal turn
+            while True:
+                message = await stt.recv()
+                # The SDK types `data` as an undiscriminated union, so read fields by name.
+                if message.type == "events":
+                    signal = getattr(message.data, "signal_type", None)
+                    if signal == "START_SPEECH" and turn and not turn.done():
+                        # ponytail: the interrupted reply is dropped from history rather than
+                        # truncated at the last spoken word. Track played audio if it matters.
+                        turn.cancel()
+                        await browser.send_json({"type": "interrupt"})
+                elif message.type == "data":
+                    transcript = (getattr(message.data, "transcript", "") or "").strip()
+                    if not transcript:
+                        continue
+                    await browser.send_json({"type": "user", "text": transcript})
+                    history.append({"role": "user", "content": transcript})
+                    turn = asyncio.create_task(speak_turn(browser, history))
+
+        try:
+            await asyncio.gather(pump_mic(), handle_transcripts())
+        except WebSocketDisconnect:
+            pass
+        finally:
+            if turn:
+                turn.cancel()
+
+
+if __name__ == "__main__":
+    import threading
+    import webbrowser
+
+    import uvicorn
+
+    url = "http://127.0.0.1:8000"
+    threading.Timer(1.0, lambda: webbrowser.open(url)).start()
+    print(f"Voice agent running at {url}")
+    uvicorn.run(app, host="127.0.0.1", port=8000)

--- a/examples/Realtime_Voice_Agent/requirements.txt
+++ b/examples/Realtime_Voice_Agent/requirements.txt
@@ -1,0 +1,5 @@
+sarvamai>=0.1.28
+fastapi>=0.115.0
+uvicorn>=0.30.0
+python-dotenv>=1.0.0
+websockets>=12.0

--- a/examples/Realtime_Voice_Agent/static/index.html
+++ b/examples/Realtime_Voice_Agent/static/index.html
@@ -1,0 +1,465 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sarvam Realtime Voice Agent</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700&family=Inter:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --void:#060806;
+    --card:#0b100e;
+    --card-edge:rgba(255,255,255,0.06);
+    --orb-core:#eafff6;
+    --orb-mid:#22d3a4;
+    --orb-deep:#083e33;
+    --ink:#f2f5f3;
+    --ink-muted:rgba(242,245,243,.5);
+    --ink-faint:rgba(242,245,243,.28);
+    --ring:#34e5b0;
+    --danger:#ff6b6b;
+  }
+  *{box-sizing:border-box;}
+  html,body{height:100%;}
+  body{
+    margin:0;
+    min-height:100vh;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    background:
+      radial-gradient(60% 50% at 50% 15%, rgba(34,211,164,.10), transparent 60%),
+      radial-gradient(80% 60% at 50% 100%, rgba(34,211,164,.06), transparent 60%),
+      var(--void);
+    font-family:"Inter", system-ui, sans-serif;
+    color:var(--ink);
+    padding:32px 16px;
+  }
+
+  .frame{
+    width:100%;
+    max-width:388px;
+    height:min(820px, 92vh);
+    background:linear-gradient(180deg, #0d1310 0%, #070a08 100%);
+    border:1px solid var(--card-edge);
+    border-radius:44px;
+    box-shadow:
+      0 0 0 1px rgba(255,255,255,.02),
+      0 30px 80px -20px rgba(0,0,0,.8),
+      0 0 120px -40px rgba(34,211,164,.25);
+    display:flex;
+    flex-direction:column;
+    overflow:hidden;
+    position:relative;
+  }
+
+  /* ---------- top bar ---------- */
+  .topbar{
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    padding:22px 22px 4px;
+    font-family:"Sora", sans-serif;
+  }
+  .topbar .side-btn{
+    width:34px; height:34px;
+    border-radius:50%;
+    border:1px solid var(--card-edge);
+    background:rgba(255,255,255,.03);
+    color:var(--ink-muted);
+    display:flex; align-items:center; justify-content:center;
+    cursor:pointer;
+    transition:border-color .2s, color .2s;
+  }
+  .topbar .side-btn:hover{ border-color:rgba(255,255,255,.2); color:var(--ink); }
+  .topbar h1{
+    font-size:15px;
+    font-weight:600;
+    letter-spacing:.01em;
+    margin:0;
+    color:var(--ink);
+  }
+
+  /* ---------- status headline ---------- */
+  .status-wrap{
+    padding:26px 30px 0;
+    text-align:center;
+  }
+  .status-line{
+    font-family:"Sora", sans-serif;
+    font-size:21px;
+    font-weight:600;
+    letter-spacing:-.01em;
+    line-height:1.35;
+    min-height:2.7em;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    transition:opacity .25s ease;
+  }
+  .status-line .dim{ color:var(--ink-muted); font-weight:500; }
+
+  /* ---------- orb ---------- */
+  .orb-stage{
+    flex:1;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    position:relative;
+    min-height:0;
+  }
+  .orb-glow{
+    position:absolute;
+    width:230px; height:230px;
+    border-radius:50%;
+    background:radial-gradient(circle, rgba(34,211,164,.55), rgba(34,211,164,0) 70%);
+    filter:blur(20px);
+    opacity:.5;
+    transition:opacity .5s ease, transform .5s ease;
+    transform:scale(1);
+  }
+  .orb-svg{
+    width:210px; height:210px;
+    position:relative;
+    filter:drop-shadow(0 0 30px rgba(34,211,164,.35));
+    transition:filter .4s ease;
+  }
+  #turbulence{ animation:swirl 22s linear infinite; }
+  @keyframes swirl{
+    0%{ baseFrequency:.010; }
+  }
+  .orb-core-anim{
+    transform-origin:105px 105px;
+    animation:breathe 4.2s ease-in-out infinite;
+  }
+  @keyframes breathe{
+    0%,100%{ transform:scale(1); }
+    50%{ transform:scale(1.035); }
+  }
+
+  body[data-state="idle"] .orb-glow{ opacity:.28; transform:scale(.9); }
+  body[data-state="idle"] .orb-core-anim{ animation-duration:6s; }
+
+  body[data-state="listening"] .orb-glow{ opacity:.55; }
+
+  body[data-state="speaking"] .orb-glow{ opacity:.85; transform:scale(1.12); }
+  body[data-state="speaking"] .orb-core-anim{ animation-duration:1.6s; }
+  body[data-state="speaking"] .orb-svg{ filter:drop-shadow(0 0 46px rgba(34,211,164,.55)); }
+
+  /* ---------- transcript ---------- */
+  .transcript-area{
+    padding:0 34px 8px;
+    text-align:center;
+    min-height:78px;
+  }
+  .subtitle{
+    font-size:14.5px;
+    line-height:1.55;
+    color:var(--ink-muted);
+    font-weight:400;
+    transition:opacity .3s ease;
+  }
+  .subtitle.user{ color:rgba(242,245,243,.72); }
+
+  .log-panel{
+    max-height:0;
+    overflow:hidden;
+    transition:max-height .35s ease;
+    border-top:1px solid transparent;
+  }
+  .log-panel.open{
+    max-height:220px;
+    overflow-y:auto;
+    border-top:1px solid var(--card-edge);
+  }
+  .log-inner{ padding:14px 22px; display:flex; flex-direction:column; gap:8px; }
+  .turn{
+    font-size:13px;
+    line-height:1.5;
+    padding:8px 12px;
+    border-radius:12px;
+    max-width:85%;
+    white-space:pre-wrap;
+  }
+  .turn.user{
+    align-self:flex-end;
+    background:rgba(34,211,164,.12);
+    color:var(--ink);
+    border:1px solid rgba(34,211,164,.18);
+  }
+  .turn.assistant{
+    align-self:flex-start;
+    background:rgba(255,255,255,.04);
+    color:var(--ink-muted);
+    border:1px solid var(--card-edge);
+  }
+
+  /* ---------- controls ---------- */
+  .controls{
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    gap:22px;
+    padding:20px 0 34px;
+  }
+  .ctrl-btn{
+    width:52px; height:52px;
+    border-radius:50%;
+    border:1px solid var(--card-edge);
+    background:rgba(255,255,255,.03);
+    color:var(--ink-muted);
+    display:flex; align-items:center; justify-content:center;
+    cursor:pointer;
+    transition:border-color .2s, color .2s, background .2s;
+  }
+  .ctrl-btn:hover{ border-color:rgba(255,255,255,.2); color:var(--ink); }
+  .ctrl-btn.danger:hover{ color:var(--danger); border-color:rgba(255,107,107,.4); }
+
+  .mic-btn{
+    width:68px; height:68px;
+    border-radius:50%;
+    border:1px solid rgba(34,211,164,.35);
+    background:radial-gradient(circle at 35% 30%, rgba(34,211,164,.35), rgba(11,16,14,.9));
+    color:var(--orb-core);
+    display:flex; align-items:center; justify-content:center;
+    cursor:pointer;
+    position:relative;
+    transition:box-shadow .3s ease, transform .15s ease;
+    box-shadow:0 0 0 0 rgba(34,211,164,.4);
+  }
+  .mic-btn:active{ transform:scale(.96); }
+  body[data-state="listening"] .mic-btn,
+  body[data-state="speaking"] .mic-btn{
+    box-shadow:0 0 0 8px rgba(34,211,164,.08), 0 0 24px rgba(34,211,164,.35);
+  }
+  body[data-active="true"] .mic-btn{
+    border-color:var(--ring);
+  }
+
+  #status-eyebrow{
+    text-align:center;
+    font-size:11px;
+    letter-spacing:.14em;
+    text-transform:uppercase;
+    color:var(--ink-faint);
+    margin-top:2px;
+  }
+
+  ::-webkit-scrollbar{ width:6px; }
+  ::-webkit-scrollbar-thumb{ background:rgba(255,255,255,.12); border-radius:3px; }
+</style>
+</head>
+<body data-state="idle" data-active="false">
+
+  <div class="frame">
+
+    <div class="topbar">
+      <button class="side-btn" id="clearBtn" title="Clear transcript" aria-label="Clear transcript">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 12a9 9 0 1 0 3-6.7"/><path d="M3 3v6h6"/></svg>
+      </button>
+      <h1>Sarvam Voice</h1>
+      <button class="side-btn" id="logToggle" title="Toggle transcript" aria-label="Toggle transcript">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h10"/></svg>
+      </button>
+    </div>
+
+    <div class="status-wrap">
+      <div class="status-line" id="statusLine">Tap the mic to start</div>
+      <div id="status-eyebrow">idle</div>
+    </div>
+
+    <div class="orb-stage">
+      <div class="orb-glow"></div>
+      <svg class="orb-svg" viewBox="0 0 210 210" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <radialGradient id="orbGradient" cx="38%" cy="32%" r="75%">
+            <stop offset="0%" stop-color="var(--orb-core)"/>
+            <stop offset="35%" stop-color="var(--orb-mid)"/>
+            <stop offset="100%" stop-color="var(--orb-deep)"/>
+          </radialGradient>
+          <filter id="orbTurbulence" x="-50%" y="-50%" width="200%" height="200%">
+            <feTurbulence id="turbulence" type="fractalNoise" baseFrequency="0.012 0.018" numOctaves="2" seed="7" result="noise">
+              <animate attributeName="baseFrequency" values="0.010 0.016;0.020 0.026;0.010 0.016" dur="14s" repeatCount="indefinite"/>
+            </feTurbulence>
+            <feDisplacementMap in="SourceGraphic" in2="noise" scale="18" xChannelSelector="R" yChannelSelector="G"/>
+          </filter>
+        </defs>
+        <g class="orb-core-anim">
+          <circle cx="105" cy="105" r="95" fill="url(#orbGradient)" filter="url(#orbTurbulence)"/>
+        </g>
+      </svg>
+    </div>
+
+    <div class="transcript-area">
+      <div class="subtitle" id="subtitle">Warm up your voice — I can hear you the moment you start.</div>
+    </div>
+
+    <div class="log-panel" id="logPanel">
+      <div class="log-inner" id="log"></div>
+    </div>
+
+    <div class="controls">
+      <button class="ctrl-btn" id="logToggle2" title="Transcript" aria-label="Show transcript">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M3 6l9 6 9-6M4 5h16v14H4z"/></svg>
+      </button>
+      <button class="mic-btn" id="toggle" title="Start talking" aria-label="Start talking">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="9" y="2" width="6" height="12" rx="3"/><path d="M5 10a7 7 0 0 0 14 0"/><path d="M12 19v3"/>
+        </svg>
+      </button>
+      <button class="ctrl-btn danger" id="endBtn" title="End session" aria-label="End session">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+      </button>
+    </div>
+
+  </div>
+
+<script>
+const MIC_SAMPLE_RATE = 16000;
+const TTS_SAMPLE_RATE = 22050;
+
+let ws, micContext, playContext, micStream;
+let playCursor = 0;          // when the next audio chunk should start
+let sources = [];            // scheduled chunks, so a barge-in can stop them
+let assistantTurn = null;    // <div> collecting the streaming reply
+
+const statusLine = document.getElementById("statusLine");
+const eyebrow = document.getElementById("status-eyebrow");
+const subtitle = document.getElementById("subtitle");
+const log = document.getElementById("log");
+const logPanel = document.getElementById("logPanel");
+const toggle = document.getElementById("toggle");
+
+function setState(state, headline, eyebrowText){
+  document.body.dataset.state = state;
+  if (headline !== undefined) statusLine.textContent = headline;
+  eyebrow.textContent = eyebrowText || state;
+}
+
+function setSubtitle(text, role){
+  subtitle.textContent = text;
+  subtitle.className = "subtitle" + (role === "user" ? " user" : "");
+}
+
+function addTurn(role, text) {
+  const div = document.createElement("div");
+  div.className = `turn ${role}`;
+  div.textContent = text;
+  log.append(div);
+  logPanel.scrollTop = logPanel.scrollHeight;
+  return div;
+}
+
+function playChunk(base64Pcm) {
+  const bytes = Uint8Array.from(atob(base64Pcm), (c) => c.charCodeAt(0));
+  const pcm = new Int16Array(bytes.buffer);
+  const buffer = playContext.createBuffer(1, pcm.length, TTS_SAMPLE_RATE);
+  const channel = buffer.getChannelData(0);
+  for (let i = 0; i < pcm.length; i++) channel[i] = pcm[i] / 32768;
+
+  const source = playContext.createBufferSource();
+  source.buffer = buffer;
+  source.connect(playContext.destination);
+  playCursor = Math.max(playCursor, playContext.currentTime);
+  source.start(playCursor);
+  playCursor += buffer.duration;
+  sources.push(source);
+  setState("speaking", "Speaking…");
+  source.onended = () => {
+    sources = sources.filter((s) => s !== source);
+    if (sources.length === 0 && document.body.dataset.active === "true") {
+      setState("listening", "Psst… speak up, I'm listening");
+    }
+  };
+}
+
+function stopPlayback() {
+  sources.forEach((s) => s.stop());
+  sources = [];
+  playCursor = 0;
+}
+
+async function start() {
+  micStream = await navigator.mediaDevices.getUserMedia({
+    audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
+  });
+
+  ws = new WebSocket(`ws://${location.host}/ws`);
+  ws.onmessage = (event) => {
+    const message = JSON.parse(event.data);
+    if (message.type === "user") {
+      addTurn("user", message.text);
+      setSubtitle(message.text, "user");
+      assistantTurn = null;
+      setState("thinking", "Thinking…");
+    } else if (message.type === "assistant_delta") {
+      if (!assistantTurn) assistantTurn = addTurn("assistant", "");
+      assistantTurn.textContent += message.text;
+      setSubtitle(assistantTurn.textContent, "assistant");
+    } else if (message.type === "audio") {
+      playChunk(message.audio);
+    } else if (message.type === "interrupt") {
+      stopPlayback();
+      assistantTurn = null;
+      setState("listening", "Psst… speak up, I'm listening");
+    } else if (message.type === "error") {
+      setState(document.body.dataset.state, message.text, "error");
+    }
+  };
+  ws.onclose = () => stop();
+
+  micContext = new AudioContext({ sampleRate: MIC_SAMPLE_RATE });
+  playContext = new AudioContext({ sampleRate: TTS_SAMPLE_RATE });
+
+  // ponytail: ScriptProcessorNode is deprecated but needs no worklet file.
+  // Move to an AudioWorklet if the main thread ever stutters.
+  const source = micContext.createMediaStreamSource(micStream);
+  const processor = micContext.createScriptProcessor(2048, 1, 1);
+  processor.onaudioprocess = (event) => {
+    if (ws.readyState !== WebSocket.OPEN) return;
+    const floats = event.inputBuffer.getChannelData(0);
+    const pcm = new Int16Array(floats.length);
+    for (let i = 0; i < floats.length; i++) {
+      pcm[i] = Math.max(-1, Math.min(1, floats[i])) * 32767;
+    }
+    ws.send(pcm.buffer);
+  };
+  source.connect(processor);
+  processor.connect(micContext.destination);
+
+  document.body.dataset.active = "true";
+  setState("listening", "Psst… speak up, I'm listening");
+  setSubtitle("Go ahead, I'm all ears.");
+  toggle.title = "Stop talking";
+}
+
+function stop() {
+  stopPlayback();
+  micStream?.getTracks().forEach((t) => t.stop());
+  micContext?.close();
+  playContext?.close();
+  if (ws?.readyState === WebSocket.OPEN) ws.close();
+  document.body.dataset.active = "false";
+  setState("idle", "Tap the mic to start");
+  setSubtitle("Warm up your voice — I can hear you the moment you start.");
+  toggle.title = "Start talking";
+}
+
+toggle.onclick = () => (document.body.dataset.active === "true" ? stop() : start());
+
+document.getElementById("endBtn").onclick = () => stop();
+
+document.getElementById("clearBtn").onclick = () => {
+  log.innerHTML = "";
+};
+
+function toggleLog() {
+  logPanel.classList.toggle("open");
+}
+document.getElementById("logToggle").onclick = toggleLog;
+document.getElementById("logToggle2").onclick = toggleLog;
+</script>
+</body>
+</html>

--- a/examples/Realtime_Voice_Agent/test_app.py
+++ b/examples/Realtime_Voice_Agent/test_app.py
@@ -1,0 +1,24 @@
+"""Self-check for the sentence chunking that feeds the TTS socket. Run: python test_app.py"""
+
+import os
+
+os.environ.setdefault("SARVAM_API_KEY", "dummy-key-for-import")
+
+from app import split_sentences
+
+# Complete sentences are flushed; the trailing fragment is held back for more tokens.
+assert split_sentences("Hello there. How are") == (["Hello there."], "How are")
+
+# The Devanagari danda ends a sentence too.
+assert split_sentences("नमस्ते। आप कैसे") == (["नमस्ते।"], "आप कैसे")
+
+# Nothing complete yet: hold everything, send nothing to TTS.
+assert split_sentences("I am still") == ([], "I am still")
+
+# A decimal number is not a sentence boundary (no whitespace after the dot).
+assert split_sentences("It costs 3.5 lakh") == ([], "It costs 3.5 lakh")
+
+# Multiple sentences in one delta all go out in order.
+assert split_sentences("One. Two! Three? ") == (["One.", "Two!", "Three?"], "")
+
+print("ok")


### PR DESCRIPTION
## What this adds


https://github.com/user-attachments/assets/b2f20de7-6841-44df-86d1-a72fd83afe64



`examples/Realtime_Voice_Agent/` — a speech-to-speech voice agent built entirely on
Sarvam's WebSocket APIs. You talk, it talks back, and you can interrupt it mid-sentence.

browser mic ──PCM──▶ FastAPI ──▶ STT streaming WS (saaras:v3)
                        │                │ transcript
                        │                ▼
                        │         Chat Completion (sarvam-105b, streamed)
                        │                │ sentences
                        │                ▼
browser speaker ◀─PCM── └────────  TTS streaming WS (bulbul:v2)

Every leg is streamed: the assistant starts speaking its first sentence while the model
is still writing the second one.

## Why it's interesting

- **Barge-in.** STT's `START_SPEECH` VAD signal fires the moment the user talks over the
  assistant. That cancels the in-flight turn task, which closes its TTS socket and clears
  the browser's playback queue — so no stale audio from an abandoned reply can arrive late.
  One STT socket is held open for the session; a fresh TTS socket is opened per turn, which
  is what makes the cancellation clean.
- **Sentence-level TTS.** LLM tokens are buffered only until a sentence boundary (including
  the Devanagari danda `।`), then pushed straight into the TTS socket.
- **No audio dependencies.** TTS is requested as `linear16`, so the browser plays raw PCM via
  the Web Audio API. No ffmpeg, no pydub. Audio is PCM in both directions — 16 kHz mono up,
  22.05 kHz down.
- Configurable language (11 supported) and speaker via `.env`.

## Notes for reviewers

- **Model choice.** `sarvam-m` is deprecated, and both remaining chat models reason before
  answering (`reasoning_effort="none"` is rejected). In testing, `sarvam-30b` regularly spent
  its entire token budget reasoning and emitted no answer at all, so the example uses
  `sarvam-105b` at `reasoning_effort="low"` with `max_tokens` large enough to cover thinking
  *plus* the reply. This is documented in the README so users don't trip on it.
- **Latency is honest in the docs.** ~5–8s from end of speech to first audio, and the README
  says plainly that the STT and TTS legs are realtime while the LLM's mandatory reasoning is
  the bottleneck — a property of today's models, not the pipeline.
- **End-of-utterance** uses a plain RMS gate over mic frames to decide when to flush STT
  (streaming STT only finalizes on flush; `END_SPEECH` follows a flush rather than causing one).
  Called out in-code as the place to swap in a real VAD for noisy rooms.

## Testing

`python test_app.py` — asserts the sentence splitter that decides when to hand text to TTS
(danda handling, decimals like `3.5` not splitting, partial fragments held back).
Verified end to end in Chrome against live Sarvam APIs.

## Known limits (documented in the README)

- An interrupted reply is dropped from history rather than truncated at the last word the user
  actually heard.
- Mic capture uses `ScriptProcessorNode` (deprecated, but needs no worklet file).
- Conversation history grows unbounded — fine for a demo, add a window for long sessions.

## Files

app.py · static/index.html · test_app.py · requirements.txt · .env.example · README.md · demo/demo.mp4