### PR TITLE
fix: Live_Video_Transcription: remove duplicate results and dead code

### DIFF
--- a/examples/Live_Video_Transcription/.gitignore
+++ b/examples/Live_Video_Transcription/.gitignore
@@ -37,8 +37,6 @@ Thumbs.db
 
 # Application specific
 static/*.mp4
-!static/demo_video.mp4
-!static/demo_video_extended.mp4
 *.log
 .env
 

--- a/examples/Live_Video_Transcription/README.md
+++ b/examples/Live_Video_Transcription/README.md
@@ -1,51 +1,43 @@
 # Live Speech Transcription & Translation Demo
 
-A real-time speech transcription and translation demo using Flask and Sarvam AI's API. This application can transcribe speech from video files and provide live translations.
+A real-time speech transcription and translation demo using Flask-SocketIO and Sarvam AI's streaming speech-to-text API. Play or upload any video with speech, and see live transcription and English translation as it plays.
+
+## How it works
+
+The browser captures the video's audio via the Web Audio API, resamples it to 16kHz mono WAV, and streams ~1 second frames to the Flask server over Socket.IO. For each client, the server opens one persistent streaming connection per mode (transcribe/translate) to the Sarvam AI API and forwards audio frames into it as they arrive; transcripts are pushed back to the browser over the same socket as they finalize.
 
 ## Features
 
 - Real-time speech transcription
 - Live translation to English
-- Support for video file playback
+- Runs transcription and translation concurrently, each with its own persistent streaming connection
 - WebSocket-based communication for instant results
-- Clean and modern UI
-- Progress tracking for both transcription and translation
 
 ## Prerequisites
 
 - Python 3.8 or higher
-- Flask and its dependencies
 - Sarvam AI API key
 
 ## Installation
 
-1. Clone the repository:
-
-```bash
-git clone <repository-url>
-cd live_transcription_demo
-```
-
-2. Create and activate a virtual environment:
+1. Create and activate a virtual environment:
 
 ```bash
 python -m venv venv
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 ```
 
-3. Install the required packages:
+2. Install the required packages:
 
 ```bash
 pip install -r requirements.txt
 ```
 
-4. Set up your Sarvam AI API key:
-   - Create a `.env` file in the root directory
-   - Add your API key:
-     ```
-     SARVAM_API_KEY=your-api-key-here
-     ```
-   - Or set it directly in `config.py`
+3. Set up your Sarvam AI API key by creating a `.env` file in this directory:
+
+```
+SARVAM_API_KEY=your-api-key-here
+```
 
 ## Usage
 
@@ -62,24 +54,21 @@ http://localhost:5001
 ```
 
 3. Use the demo:
-   - Click "Start Transcription" to begin transcribing
-   - Click "Start Translation" to begin translating
-   - Use the provided demo video or upload your own
+   - Upload a video with speech
+   - Click "Start Transcription" and/or "Start Translation"
    - Watch as transcriptions and translations appear in real-time
 
 ## Project Structure
 
 ```
-live_transcription_demo/
-├── app.py                 # Main Flask application
+Live_Video_Transcription/
+├── app.py               # Flask + Socket.IO server, persistent Sarvam streaming sessions
 ├── config.py             # Configuration settings
 ├── requirements.txt      # Python dependencies
 ├── static/
-│   ├── style.css        # CSS styles
-│   ├── demo_video.mp4   # Sample video for testing
-│   └── demo_video_extended.mp4
+│   └── style.css        # CSS styles
 └── templates/
-    └── index.html       # Main application template
+    └── index.html        # Main application page (video capture, WAV encoding, Socket.IO client)
 ```
 
 ## Configuration
@@ -87,31 +76,14 @@ live_transcription_demo/
 You can modify the following settings in `config.py`:
 
 - `SARVAM_API_KEY`: Your Sarvam AI API key
-- `HOST`: Server host (default: "0.0.0.0")
-- `PORT`: Server port (default: 5001)
-- `AUDIO_SAMPLE_RATE`: Audio processing rate (default: 16000)
-- `CHUNK_DURATION_MS`: Audio chunk duration (default: 3000ms)
+- `HOST` / `PORT`: Server bind address (default: `127.0.0.1:5001`)
+- `API_LANGUAGE`: Source language passed to the transcription stream (default: `"unknown"`, i.e. auto-detect)
 
-## API Endpoints
+## Socket.IO events
 
-The application uses WebSocket endpoints for real-time communication:
-
-- `/`: Main application interface
-- WebSocket events:
-  - `audio_chunk`: Handle incoming audio for transcription
-  - `translation_chunk`: Handle incoming audio for translation
-  - `transcription_result`: Receive transcription results
-  - `translation_result`: Receive translation results
-
-## Contributing
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+- `start_stream` / `stop_stream` (client → server): open/close a persistent streaming session for `{ mode: "transcribe" | "translate" }`
+- `audio_chunk` / `translation_chunk` (client → server): forward a WAV audio frame, `{ audio: "<base64>" }`
+- `transcription_result` / `translation_result` (server → client): a finalized piece of text, `{ text: "..." }`
+- `video_control` (client → server): informational play/pause events
+- `status` / `error` (server → client): connection status and error messages
 

--- a/examples/Live_Video_Transcription/app.py
+++ b/examples/Live_Video_Transcription/app.py
@@ -1,9 +1,6 @@
 from flask import Flask, render_template, request
 from flask_socketio import SocketIO, emit
 import asyncio
-import base64
-import io
-from pydub import AudioSegment
 from sarvamai import AsyncSarvamAI
 import logging
 import threading
@@ -14,80 +11,11 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
-app.config["SECRET_KEY"] = "live_transcription_demo"
-socketio = SocketIO(app, cors_allowed_origins="*")
+app.config["SECRET_KEY"] = config.SECRET_KEY
+socketio = SocketIO(app, cors_allowed_origins=config.CORS_ALLOWED_ORIGINS)
 
 # Sarvam AI client
 SARVAM_API_KEY = config.SARVAM_API_KEY
-
-# Global variables
-active_clients = set()
-recent_transcriptions = []
-recent_translations = []
-translation_chunk_counter = 0
-translation_processing_times = []
-processed_chunks = set()  # Track processed chunk names
-
-
-def create_silence_base64():
-    """Create silence audio for Sarvam API"""
-    silence = AudioSegment.silent(duration=1000, frame_rate=16000)
-    silence = silence.set_channels(1)
-
-    # Use an in-memory buffer — NamedTemporaryFile can't be reopened on Windows
-    buf = io.BytesIO()
-    silence.export(buf, format="wav")
-    return base64.b64encode(buf.getvalue()).decode("utf-8")
-
-
-def combine_silence_and_audio(audio_base64):
-    """Combine 1 second silence with audio data into single Base64 chunk"""
-    try:
-        logger.info(f"Starting audio combination. Input length: {len(audio_base64)}")
-
-        # Decode the incoming audio
-        audio_bytes = base64.b64decode(audio_base64)
-        logger.info(f"Decoded audio bytes: {len(audio_bytes)} bytes")
-
-        # Create silence (1 second at 16kHz, mono)
-        silence = AudioSegment.silent(duration=1000, frame_rate=16000)
-        silence = silence.set_channels(1)
-        logger.info(
-            f"Created silence: {len(silence)} ms, {silence.frame_rate}Hz, {silence.channels} channels"
-        )
-
-        # Load the audio data from an in-memory buffer (Windows-safe)
-        audio_segment = AudioSegment.from_file(io.BytesIO(audio_bytes), format="wav")
-
-        logger.info(
-            f"Loaded audio segment: {len(audio_segment)} ms, {audio_segment.frame_rate}Hz, {audio_segment.channels} channels"
-        )
-
-        # Ensure audio is in correct format (16kHz, mono)
-        audio_segment = audio_segment.set_frame_rate(16000).set_channels(1)
-        logger.info(
-            f"Resampled audio: {len(audio_segment)} ms, {audio_segment.frame_rate}Hz, {audio_segment.channels} channels"
-        )
-
-        # Combine: silence first, then audio
-        combined_audio = silence + audio_segment
-        logger.info(
-            f"Combined audio: {len(combined_audio)} ms, {combined_audio.frame_rate}Hz, {combined_audio.channels} channels"
-        )
-
-        # Export combined audio to Base64 via in-memory buffer (Windows-safe)
-        buf = io.BytesIO()
-        combined_audio.export(buf, format="wav")
-        result = base64.b64encode(buf.getvalue()).decode("utf-8")
-        logger.info(f"Final combined audio Base64 length: {len(result)}")
-        return result
-
-    except Exception as e:
-        logger.error(f"Error combining silence and audio: {e}")
-        import traceback
-
-        logger.error(f"Traceback: {traceback.format_exc()}")
-        return audio_base64  # Return original if combination fails
 
 
 def _extract_text(resp):
@@ -128,13 +56,19 @@ class StreamingSession:
         if self._stopped:
             return
         # Scheduled onto the session's own loop from the Socket.IO thread.
-        asyncio.run_coroutine_threadsafe(self.queue.put(audio_b64), self.loop)
+        try:
+            asyncio.run_coroutine_threadsafe(self.queue.put(audio_b64), self.loop)
+        except RuntimeError:
+            self._stopped = True  # loop died (e.g. connection never opened)
 
     def stop(self):
         if self._stopped:
             return
         self._stopped = True
-        asyncio.run_coroutine_threadsafe(self.queue.put(None), self.loop)
+        try:
+            asyncio.run_coroutine_threadsafe(self.queue.put(None), self.loop)
+        except RuntimeError:
+            pass  # loop already dead, nothing to stop
 
     def _run(self):
         asyncio.set_event_loop(self.loop)
@@ -142,6 +76,16 @@ class StreamingSession:
             self.loop.run_until_complete(self._session())
         except Exception as e:
             logger.error(f"[{self.mode}] session loop error: {e}")
+            self._stopped = True
+            # Unregister so the client can retry with a fresh start_stream,
+            # and let the browser know why nothing is coming through.
+            streaming_sessions.pop((self.sid, self.mode), None)
+            with app.app_context():
+                socketio.emit(
+                    "error",
+                    {"message": f"Failed to start {self.mode} stream: {e}"},
+                    to=self.sid,
+                )
         finally:
             self.loop.close()
 
@@ -151,7 +95,7 @@ class StreamingSession:
 
         if self.mode == "transcribe":
             conn = client.speech_to_text_streaming.connect(
-                language_code="unknown", model="saaras:v3"
+                language_code=config.API_LANGUAGE, model="saaras:v3"
             )
         else:
             conn = client.speech_to_text_translate_streaming.connect(model="saaras:v3")
@@ -198,16 +142,9 @@ streaming_sessions = {}
 
 def emit_streaming_result(sid, mode, text):
     """Emit a transcript/translation result to a specific client."""
-    result_data = {"text": text, "status": "completed"}
-    if mode == "transcribe":
-        add_transcription_to_queue(result_data)
-        event = "transcription_result"
-    else:
-        add_translation_to_queue(result_data)
-        event = "translation_result"
-
+    event = "transcription_result" if mode == "transcribe" else "translation_result"
     with app.app_context():
-        socketio.emit(event, result_data, to=sid)
+        socketio.emit(event, {"text": text}, to=sid)
 
 
 @app.route("/")
@@ -224,7 +161,6 @@ def index():
 def handle_connect():
     """Handle client connection"""
     logger.info(f"Client connected: {request.sid}")
-    active_clients.add(request.sid)
     emit("status", {"message": "Connected to transcription service"})
 
 
@@ -232,7 +168,6 @@ def handle_connect():
 def handle_disconnect():
     """Handle client disconnection"""
     logger.info(f"Client disconnected: {request.sid}")
-    active_clients.discard(request.sid)
     # Tear down any streaming sessions this client owned
     for mode in ("transcribe", "translate"):
         session = streaming_sessions.pop((request.sid, mode), None)
@@ -282,66 +217,6 @@ def handle_video_control(data):
         emit("status", {"message": "Video paused - transcription paused"})
 
 
-def add_transcription_to_queue(transcription_data):
-    """Add transcription to both WebSocket and polling queue"""
-    recent_transcriptions.append(transcription_data)
-    # Keep only last 50 transcriptions
-    if len(recent_transcriptions) > 50:
-        recent_transcriptions.pop(0)
-
-
-def add_translation_to_queue(translation_data):
-    """Add translation to both WebSocket and polling queue"""
-    recent_translations.append(translation_data)
-    # Keep only last 50 translations
-    if len(recent_translations) > 50:
-        recent_translations.pop(0)
-
-
-@app.route("/get_transcriptions")
-def get_transcriptions():
-    """Polling endpoint for transcriptions as WebSocket fallback"""
-    return {"transcriptions": recent_transcriptions}
-
-
-@app.route("/get_translations")
-def get_translations():
-    """Polling endpoint for translations as WebSocket fallback"""
-    return {"translations": recent_translations}
-
-
-@app.route("/clear_transcriptions")
-def clear_transcriptions():
-    """Clear transcription queue"""
-    recent_transcriptions.clear()
-    return {"status": "cleared"}
-
-
-@app.route("/clear_translations")
-def clear_translations():
-    """Clear translation queue"""
-    recent_translations.clear()
-    return {"status": "cleared"}
-
-
-@app.route("/translation_stats")
-def translation_stats():
-    """Get translation processing statistics"""
-    global translation_chunk_counter, translation_processing_times
-
-    avg_time = 0
-    if translation_processing_times:
-        avg_time = sum(translation_processing_times) / len(translation_processing_times)
-
-    return {
-        "total_chunks_processed": translation_chunk_counter,
-        "recent_translations": len(recent_translations),
-        "average_processing_time": avg_time,
-        "processing_times": translation_processing_times,
-        "translation_queue_size": len(recent_translations),
-    }
-
-
 @socketio.on("audio_chunk")
 def handle_audio_chunk(data):
     """Forward an incoming audio chunk into the persistent transcription session."""
@@ -383,5 +258,7 @@ def handle_translation_chunk(data):
 
 if __name__ == "__main__":
     logger.info("Starting Live Transcription Demo Server...")
-    logger.info("Open http://localhost:5001 in your browser")
-    socketio.run(app, debug=False, host="127.0.0.1", port=5001, allow_unsafe_werkzeug=True)
+    logger.info(f"Open http://{config.HOST}:{config.PORT} in your browser")
+    socketio.run(
+        app, debug=config.DEBUG, host=config.HOST, port=config.PORT, allow_unsafe_werkzeug=True
+    )

--- a/examples/Live_Video_Transcription/config.py
+++ b/examples/Live_Video_Transcription/config.py
@@ -8,26 +8,13 @@ load_dotenv()
 SARVAM_API_KEY = os.getenv("SARVAM_API_KEY", "YOUR_API_KEY")
 
 # Server Configuration
-HOST = "0.0.0.0"
+HOST = "127.0.0.1"
 PORT = 5001
 DEBUG = False
 
-# Audio Processing Settings
-AUDIO_SAMPLE_RATE = 16000
-AUDIO_CHANNELS = 1
-CHUNK_DURATION_MS = 3000  # 3 seconds
-
-# API Settings
-API_LANGUAGE = "unknown"  # Options: "en-IN", "hi", "unknown"
-API_TIMEOUT = 10.0  # seconds
+# Streaming Settings
+API_LANGUAGE = "unknown"  # Options: "en-IN", "hi-IN", "unknown" (auto-detect)
 
 # Flask Configuration
 SECRET_KEY = "live_transcription_demo_secret_key"
 CORS_ALLOWED_ORIGINS = "*"
-
-# File Upload Settings
-MAX_CONTENT_LENGTH = 500 * 1024 * 1024  # 500MB
-UPLOAD_FOLDER = "static"
-
-# Logging Configuration
-LOG_LEVEL = "INFO"  # DEBUG, INFO, WARNING, ERROR

--- a/examples/Live_Video_Transcription/requirements.txt
+++ b/examples/Live_Video_Transcription/requirements.txt
@@ -1,11 +1,7 @@
 Flask==2.3.3
 Flask-SocketIO==5.3.6
 python-socketio==5.9.0
-eventlet==0.33.3
-pydub==0.25.1
-sarvamai>=0.1.28
-python-dotenv>=1.0.0
-yt-dlp==2023.10.13
-gunicorn==21.2.0
 python-engineio==4.7.1
-websockets==12.0 
+simple-websocket==1.0.0
+sarvamai>=0.1.28
+python-dotenv>=1.0.0 

--- a/examples/Live_Video_Transcription/templates/index.html
+++ b/examples/Live_Video_Transcription/templates/index.html
@@ -20,16 +20,15 @@
             <!-- Video Section -->
             <div class="video-section">
                 <h2>📹 Video Player</h2>
-                <video 
-                    id="demoVideo" 
-                    controls 
-                    width="100%" 
+                <video
+                    id="demoVideo"
+                    controls
+                    width="100%"
                     height="auto"
                     crossorigin="anonymous"
                     muted="false">
-                    <!-- Optional bundled demo video; otherwise upload your own below -->
-                    <source src="{{ url_for('static', filename='test2.mp4') }}" type="video/mp4">
-                    <p>Your browser doesn't support HTML5 video. Please upload a video file.</p>
+                    <!-- No video is bundled with this demo; upload one below -->
+                    Your browser doesn't support HTML5 video.
                 </video>
 
                 <!-- Video Upload -->
@@ -87,29 +86,19 @@
         let socket = io();
         let isRecording = false;
         let isTranslating = false;
-        let mediaRecorder;
-        let audioChunks = [];
         let chunkCounter = 0;
         let translationChunkCounter = 0;
         let startTime;
-        let pollingInterval = null;
-        let translationPollingInterval = null;
-        let lastTranscriptionCount = 0;
-        let lastTranslationCount = 0;
-        
+        let videoLoaded = false;
+
         // DOM elements
         const video = document.getElementById('demoVideo');
-        const startBtn = document.getElementById('startTranscription');
-        const stopBtn = document.getElementById('stopTranscription');
         const status = document.getElementById('status');
-        const transcriptionOutput = document.getElementById('transcriptionOutput');
-        const chunksCounter = document.getElementById('chunksProcessed');
         const timeDisplay = document.getElementById('currentTime');
-        
+
         // Audio processing variables
         let audioContext, mediaStreamSource, processor;
-        let isTranscribing = false;
-        
+
         // Load a user-selected video file into the player
         const videoUpload = document.getElementById('videoUpload');
         if (videoUpload) {
@@ -119,6 +108,7 @@
                 const url = URL.createObjectURL(file);
                 video.src = url;
                 video.load();
+                videoLoaded = true;
                 updateStatus(`Loaded: ${file.name}`, 'info');
             });
         }
@@ -136,51 +126,20 @@
             return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
         }
         
-        // SIMPLE transcription display function
-        function addTranscription(text, timestamp) {
-            // Remove placeholder if present
-            const placeholder = transcriptionOutput.querySelector('.placeholder');
-            if (placeholder) {
-                placeholder.remove();
-            }
-            
-            // Create transcription item
-            const transcriptionItem = document.createElement('div');
-            transcriptionItem.className = 'transcription-item';
-            transcriptionItem.innerHTML = `
-                <span class="timestamp">[${formatTime(timestamp)}]</span>
-                <span class="text">${text}</span>
-            `;
-            
-            // Add to output
-            transcriptionOutput.appendChild(transcriptionItem);
-            transcriptionOutput.scrollTop = transcriptionOutput.scrollHeight;
-        }
-        
-        // DIRECT WebSocket event handlers
+        // WebSocket event handlers
         socket.on('connect', function() {
             console.log('✅ Connected to server');
             updateStatus('Connected to transcription service', 'success');
         });
         
-        socket.on('transcription_result', function(data) { 
-            console.log('Received transcription:', data);
-            displayTranscription(data);
+        socket.on('transcription_result', function(data) {
+            displayResult('transcriptionOutput', data && data.text);
         });
-        
-        socket.on('translation_result', function(data) { 
-            console.log('Received translation:', data);
-            displayTranslation(data);
+
+        socket.on('translation_result', function(data) {
+            displayResult('translationOutput', data && data.text);
         });
-        
-        socket.on('transcription_status', function(data) {
-            console.log('Transcription status:', data.status);
-        });
-        
-        socket.on('translation_status', function(data) {
-            console.log('Translation status:', data.status);
-        });
-        
+
         socket.on('status', function(data) {
             if (data && data.message) {
                 updateStatus(data.message, 'info');
@@ -196,34 +155,7 @@
             console.log('❌ Disconnected from server');
             updateStatus('Disconnected', 'error');
         });
-        
-        // POLLING BACKUP for transcriptions
-        function startPolling() {
-            pollingInterval = setInterval(() => {
-                fetch('/get_transcriptions')
-                    .then(response => response.json())
-                    .then(data => {
-                        const transcriptions = data.transcriptions || [];
-                        if (transcriptions.length > lastTranscriptionCount) {
-                            // Process new transcriptions
-                            for (let i = lastTranscriptionCount; i < transcriptions.length; i++) {
-                                const t = transcriptions[i];
-                                addTranscription(t.text, t.timestamp);
-                            }
-                            lastTranscriptionCount = transcriptions.length;
-                        }
-                    })
-                    .catch(error => console.error('Polling error:', error));
-            }, 1000); // Poll every second
-        }
-        
-        function stopPolling() {
-            if (pollingInterval) {
-                clearInterval(pollingInterval);
-                pollingInterval = null;
-            }
-        }
-        
+
         // Video event handlers
         video.addEventListener('timeupdate', function() {
             timeDisplay.textContent = formatTime(video.currentTime);
@@ -248,15 +180,16 @@
         
         function startTranscription() {
             if (isRecording) return;
-            
+            if (!videoLoaded) {
+                updateStatus('Please upload a video first', 'error');
+                return;
+            }
+
             isRecording = true;
             startTime = Date.now();
             chunkCounter = 0;
-            
-            // Clear transcriptions first
-            fetch('/clear_transcriptions');
             clearTranscriptionDisplay();
-            
+
             // Update UI
             document.getElementById('startTranscription').disabled = true;
             document.getElementById('stopTranscription').disabled = false;
@@ -269,12 +202,11 @@
             if (!audioContext) {
                 startRecording();
             }
-            startPolling();
         }
 
         function stopTranscription() {
             if (!isRecording) return;
-            
+
             isRecording = false;
 
             // Update UI
@@ -289,24 +221,20 @@
             if (!isTranslating) {
                 stopRecording();
             }
-            
-            if (pollingInterval) {
-                clearInterval(pollingInterval);
-                pollingInterval = null;
-            }
         }
 
         function startTranslation() {
             if (isTranslating) return;
-            
+            if (!videoLoaded) {
+                updateStatus('Please upload a video first', 'error');
+                return;
+            }
+
             isTranslating = true;
             startTime = Date.now();
             translationChunkCounter = 0;
-            
-            // Clear translations first
-            fetch('/clear_translations');
             clearTranslationDisplay();
-            
+
             // Update UI
             document.getElementById('startTranslation').disabled = true;
             document.getElementById('stopTranslation').disabled = false;
@@ -319,12 +247,11 @@
             if (!audioContext) {
                 startRecording();
             }
-            startTranslationPolling();
         }
 
         function stopTranslation() {
             if (!isTranslating) return;
-            
+
             isTranslating = false;
 
             // Update UI
@@ -338,11 +265,6 @@
             // Stop recording if transcription is also not active
             if (!isRecording) {
                 stopRecording();
-            }
-            
-            if (translationPollingInterval) {
-                clearInterval(translationPollingInterval);
-                translationPollingInterval = null;
             }
         }
         
@@ -411,146 +333,57 @@
             return btoa(binaryString);
         }
 
-        // Send audio chunk to server
-        function sendTranscriptionChunk(audioChunks, timestamp) {
-            console.log('📝 sendTranscriptionChunk called with:', audioChunks.length, 'chunks');
-            if (audioChunks.length === 0) {
-                console.warn('📝 No transcription chunks to send!');
-                return;
-            }
-            
-            console.log(`📝 Sending transcription chunk at ${timestamp}s`);
-            
-            // Combine all audio chunks
-            const totalLength = audioChunks.reduce((sum, chunk) => sum + chunk.length, 0);
-            const combinedBuffer = new Int16Array(totalLength);
-            let offset = 0;
-            
-            for (const chunk of audioChunks) {
-                combinedBuffer.set(chunk, offset);
-                offset += chunk.length;
-            }
-            
-            console.log('📝 Combined buffer length:', combinedBuffer.length);
-            
-            // Resample from 44.1kHz to 16kHz
-            const originalSampleRate = audioContext.sampleRate;
-            const targetSampleRate = 16000;
-            const resampledBuffer = resampleAudio(combinedBuffer, originalSampleRate, targetSampleRate);
-            
-            console.log('📝 Resampled buffer length:', resampledBuffer.length);
-            
-            // Create WAV file
-            const wavBuffer = encodeWAV(resampledBuffer, targetSampleRate);
-            const base64Audio = arrayBufferToBase64(wavBuffer);
-            
-            console.log('📝 Base64 audio length:', base64Audio.length);
-            
-            // Send via WebSocket
-            const chunkData = {
-                audio: base64Audio,
-                timestamp: timestamp,
-                chunkName: `chunk_${++chunkCounter}`
-            };
-            
-            console.log(`📝 Emitting audio_chunk: ${chunkData.chunkName}, size: ${base64Audio.length} chars`);
-            socket.emit('audio_chunk', chunkData);
-            
-            // Update UI
-            document.getElementById('chunksProcessed').textContent = chunkCounter;
-            document.getElementById('currentTime').textContent = formatTime(timestamp);
-        }
+        // Combine buffered audio frames into one WAV chunk and stream it to the server
+        function sendAudioChunk(mode, audioChunks, videoTime) {
+            if (audioChunks.length === 0) return;
 
-        // Send translation chunk to server
-        function sendTranslationChunk(audioChunks, timestamp) {
-            console.log('🌍 sendTranslationChunk called with:', audioChunks.length, 'chunks');
-            if (audioChunks.length === 0) {
-                console.warn('🌍 No translation chunks to send!');
-                return;
-            }
-            
-            console.log(`🌍 Sending translation chunk at ${timestamp}s`);
-            
-            // Combine all audio chunks
             const totalLength = audioChunks.reduce((sum, chunk) => sum + chunk.length, 0);
             const combinedBuffer = new Int16Array(totalLength);
             let offset = 0;
-            
             for (const chunk of audioChunks) {
                 combinedBuffer.set(chunk, offset);
                 offset += chunk.length;
             }
-            
-            console.log('🌍 Combined buffer length:', combinedBuffer.length);
-            
-            // Resample from 44.1kHz to 16kHz
-            const originalSampleRate = audioContext.sampleRate;
-            const targetSampleRate = 16000;
-            const resampledBuffer = resampleAudio(combinedBuffer, originalSampleRate, targetSampleRate);
-            
-            console.log('🌍 Resampled buffer length:', resampledBuffer.length);
-            
-            // Create WAV file
-            const wavBuffer = encodeWAV(resampledBuffer, targetSampleRate);
-            const base64Audio = arrayBufferToBase64(wavBuffer);
-            
-            console.log('🌍 Base64 audio length:', base64Audio.length);
-            
-            // Send via WebSocket
-            const chunkData = {
-                audio: base64Audio,
-                timestamp: timestamp,
-                chunkName: `chunk_${++translationChunkCounter}`
-            };
-            
-            console.log(`🌍 Emitting translation_chunk: ${chunkData.chunkName}, size: ${base64Audio.length} chars`);
-            socket.emit('translation_chunk', chunkData);
-            
-            // Update UI
-            document.getElementById('translationChunksProcessed').textContent = translationChunkCounter;
-            document.getElementById('translationCurrentTime').textContent = formatTime(timestamp);
+
+            // Resample to the 16kHz mono the API expects
+            const resampledBuffer = resampleAudio(combinedBuffer, audioContext.sampleRate, 16000);
+            const base64Audio = arrayBufferToBase64(encodeWAV(resampledBuffer, 16000));
+
+            if (mode === 'transcribe') {
+                socket.emit('audio_chunk', { audio: base64Audio });
+                document.getElementById('chunksProcessed').textContent = ++chunkCounter;
+                document.getElementById('currentTime').textContent = formatTime(videoTime);
+            } else {
+                socket.emit('translation_chunk', { audio: base64Audio });
+                document.getElementById('translationChunksProcessed').textContent = ++translationChunkCounter;
+                document.getElementById('translationCurrentTime').textContent = formatTime(videoTime);
+            }
         }
         
         // Helper functions for recording
         async function startRecording() {
             try {
-                console.log('🎙️ Starting audio recording...');
-                
                 // Ensure video is playing and not muted
                 video.muted = false;
                 video.volume = 1.0;
-                
-                // Force play with audio
                 if (video.paused) {
                     await video.play();
                 }
-                
-                console.log('📹 Video state:', {
-                    paused: video.paused,
-                    muted: video.muted,
-                    volume: video.volume,
-                    currentTime: video.currentTime
-                });
-                
+
                 // Create audio context to capture video audio
                 audioContext = new (window.AudioContext || window.webkitAudioContext)();
-                console.log('🔊 Audio context created, sample rate:', audioContext.sampleRate);
-                
+
                 // Create media stream from video
                 const stream = video.captureStream();
-                const audioTracks = stream.getAudioTracks();
-                console.log('🎵 Audio tracks:', audioTracks.length);
-                
-                if (audioTracks.length === 0) {
-                    throw new Error('No audio tracks found in video stream!');
+                if (stream.getAudioTracks().length === 0) {
+                    throw new Error('No audio track found in this video file.');
                 }
-                
+
                 mediaStreamSource = audioContext.createMediaStreamSource(stream);
-                
+
                 // Create script processor for audio chunks
                 processor = audioContext.createScriptProcessor(4096, 1, 1);
-                console.log('⚙️ Audio processor created');
-                
+
                 // Separate buffers per mode so transcription and translation can
                 // run simultaneously without stealing each other's audio.
                 let transcriptionChunks = [];
@@ -581,7 +414,7 @@
                         if (transcriptionChunks.length > 0) {
                             const chunksToSend = [...transcriptionChunks];
                             transcriptionChunks = [];
-                            sendTranscriptionChunk(chunksToSend, video.currentTime);
+                            sendAudioChunk('transcribe', chunksToSend, video.currentTime);
                         }
                         lastChunkTime = currentTime;
                     }
@@ -591,7 +424,7 @@
                         if (translationChunks.length > 0) {
                             const chunksToSend = [...translationChunks];
                             translationChunks = [];
-                            sendTranslationChunk(chunksToSend, video.currentTime);
+                            sendAudioChunk('translate', chunksToSend, video.currentTime);
                         }
                         lastTranslationTime = currentTime;
                     }
@@ -602,12 +435,32 @@
                 processor.connect(audioContext.destination);
                 
                 console.log('✅ Audio recording setup complete!');
-                
+
             } catch (error) {
                 console.error('❌ Error starting recording:', error);
+                updateStatus(`Could not capture audio: ${error.message}`, 'error');
+                // Undo everything startTranscription/startTranslation already set up,
+                // so the buttons don't keep claiming a stream is running, and so the
+                // next click retries capture from scratch instead of silently
+                // no-op'ing on a half-initialized audioContext.
+                resetStreamingState();
             }
         }
-        
+
+        // Cancel any in-progress/active streams and return the UI to idle.
+        // Used when audio capture fails partway through start*().
+        function resetStreamingState() {
+            isRecording = false;
+            isTranslating = false;
+            document.getElementById('startTranscription').disabled = false;
+            document.getElementById('stopTranscription').disabled = true;
+            document.getElementById('startTranslation').disabled = false;
+            document.getElementById('stopTranslation').disabled = true;
+            socket.emit('stop_stream', { mode: 'transcribe' });
+            socket.emit('stop_stream', { mode: 'translate' });
+            stopRecording();
+        }
+
         function stopRecording() {
             if (processor) {
                 processor.disconnect();
@@ -623,71 +476,45 @@
             }
         }
         
-        // Display functions
-        function displayTranscription(data) {
-            if (data && data.text && data.text.trim()) {
-                const output = document.getElementById('transcriptionOutput');
-                const placeholder = output.querySelector('.placeholder');
-                if (placeholder) placeholder.remove();
-                
-                const transcriptionElement = document.createElement('div');
-                transcriptionElement.className = 'transcription-item';
-                transcriptionElement.innerHTML = `
-                    <span class="timestamp">[${formatTime(data.timestamp || 0)}]</span>
-                    <span class="text">${data.text}</span>
-                `;
-                
-                output.appendChild(transcriptionElement);
-                output.scrollTop = output.scrollHeight;
-            }
+        // Append a result line to the given output panel, tagged with time elapsed
+        // since the stream started. (Text is untrusted model output, so it's set via
+        // textContent rather than innerHTML to avoid injecting markup.)
+        function displayResult(outputId, text) {
+            if (!text || !text.trim()) return;
+
+            const output = document.getElementById(outputId);
+            const placeholder = output.querySelector('.placeholder');
+            if (placeholder) placeholder.remove();
+
+            const elapsed = startTime ? (Date.now() - startTime) / 1000 : 0;
+            const item = document.createElement('div');
+            item.className = 'transcription-item';
+
+            const timestampSpan = document.createElement('span');
+            timestampSpan.className = 'timestamp';
+            timestampSpan.textContent = `[${formatTime(elapsed)}]`;
+
+            const textSpan = document.createElement('span');
+            textSpan.className = 'text';
+            textSpan.textContent = text;
+
+            item.append(timestampSpan, textSpan);
+            output.appendChild(item);
+            output.scrollTop = output.scrollHeight;
         }
-        
-        function displayTranslation(data) {
-            if (data && data.text && data.text.trim()) {
-                const output = document.getElementById('translationOutput');
-                const placeholder = output.querySelector('.placeholder');
-                if (placeholder) placeholder.remove();
-                
-                const translationElement = document.createElement('div');
-                translationElement.className = 'transcription-item';
-                translationElement.innerHTML = `
-                    <span class="timestamp">[${formatTime(data.timestamp || 0)}]</span>
-                    <span class="text">${data.text}</span>
-                `;
-                
-                output.appendChild(translationElement);
-                output.scrollTop = output.scrollHeight;
-            }
-        }
-        
+
         function clearTranscriptionDisplay() {
             const output = document.getElementById('transcriptionOutput');
             output.innerHTML = '<p class="placeholder">Transcriptions will appear here in real-time...</p>';
             document.getElementById('chunksProcessed').textContent = '0';
             document.getElementById('currentTime').textContent = '00:00';
         }
-        
+
         function clearTranslationDisplay() {
             const output = document.getElementById('translationOutput');
             output.innerHTML = '<p class="placeholder">Translations will appear here in real-time...</p>';
             document.getElementById('translationChunksProcessed').textContent = '0';
             document.getElementById('translationCurrentTime').textContent = '00:00';
-        }
-        
-        // Translation polling
-        function startTranslationPolling() {
-            translationPollingInterval = setInterval(() => {
-                fetch('/get_translations')
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data.translations && data.translations.length > lastTranslationCount) {
-                            const newTranslations = data.translations.slice(lastTranslationCount);
-                            newTranslations.forEach(translation => displayTranslation(translation));
-                            lastTranslationCount = data.translations.length;
-                        }
-                    })
-                    .catch(error => console.error('Translation polling error:', error));
-            }, 1000);
         }
     </script>
 </body>


### PR DESCRIPTION
## What was wrong
Transcripts and translations were rendered twice (live WebSocket push + a redundant polling
endpoint reading the same data), and every line showed a frozen `[00:00]` timestamp. The demo
also had a broken video reference (404), ~250 lines of dead code from an older implementation,
ignored config settings, and unused/risky dependencies.

## What's fixed
Removed the duplicate polling path and dead code, fixed timestamps to reflect real elapsed
time, removed the broken video reference, wired up `config.py` properly, cleaned up
`requirements.txt`, and made streaming sessions recover cleanly on connection failure instead
of getting stuck.

