### PR TITLE
fix(Live_Video_Transcription): migrate to unified STT streaming with …

### DIFF
--- a/examples/Live_Video_Transcription/app.py
+++ b/examples/Live_Video_Transcription/app.py
@@ -93,12 +93,12 @@ class StreamingSession:
         client = AsyncSarvamAI(api_subscription_key=SARVAM_API_KEY)
         logger.info(f"[{self.mode}] opening persistent streaming connection...")
 
-        if self.mode == "transcribe":
-            conn = client.speech_to_text_streaming.connect(
-                language_code=config.API_LANGUAGE, model="saaras:v3"
-            )
-        else:
-            conn = client.speech_to_text_translate_streaming.connect(model="saaras:v3")
+        # Both modes go through the same unified speech_to_text_streaming
+        # endpoint; the `mode` param ("transcribe" vs "translate") picks the
+        # behavior, and both still call ws.transcribe() to send audio.
+        conn = client.speech_to_text_streaming.connect(
+            language_code=config.API_LANGUAGE, model="saaras:v3", mode=self.mode
+        )
 
         async with conn as ws:
             logger.info(f"[{self.mode}] connected")
@@ -108,10 +108,7 @@ class StreamingSession:
                     audio_b64 = await self.queue.get()
                     if audio_b64 is None:  # stop sentinel
                         break
-                    if self.mode == "transcribe":
-                        await ws.transcribe(audio=audio_b64)
-                    else:
-                        await ws.translate(audio=audio_b64)
+                    await ws.transcribe(audio=audio_b64)
 
                 # Flush any buffered audio so the final segment is emitted.
                 await ws.flush()


### PR DESCRIPTION
## Summary
- Migrates Live Video Transcription off the deprecated `speech_to_text_translate_streaming` client
- Both transcribe and translate now go through the single unified `speech_to_text_streaming` endpoint, selected via `mode="transcribe"` / `mode="translate"`
- Both modes now call `ws.transcribe()` to send audio (the unified socket client has no separate `.translate()` method)

## Test plan
- [x] Ran a live end-to-end test against the Sarvam API with a sample Kannada WAV: `mode=transcribe` returned Kannada text, `mode=translate` returned correct English translation
- [x] Started the Flask-SocketIO app locally and confirmed the page loads and sockets connect
