### PR TITLE
fix(ci): detect unquoted TS/JS model keys in allowlist scan

### DIFF
--- a/scripts/sarvam_rules.py
+++ b/scripts/sarvam_rules.py
@@ -9,10 +9,12 @@ from pathlib import Path
 
 RULES_PATH = Path(__file__).resolve().parent / "sarvam_api_rules.json"
 
-# Matches model assignments in Python, TS, JSON, and notebooks.
+# Matches model assignments in Python, TS/JS, JSON, and notebooks.
+# Includes unquoted JS/TS object keys: model: "sarvam-30b"
 MODEL_VALUE_RE = re.compile(
     r"""
     ["']model["']\s*:\s*["']([^"']+)["']     # "model": "sarvam-30b"
+    |(?<![A-Za-z0-9_])model\s*:\s*["']([^"']+)["']  # model: "sarvam-30b" (TS/JS)
     |model\s*=\s*["']([^"']+)["']            # model="saaras:v3"
     """,
     re.IGNORECASE | re.VERBOSE,
@@ -93,7 +95,7 @@ def extract_models(line: str) -> list[str]:
     """Return Sarvam model strings referenced on a line of code."""
     models: list[str] = []
     for match in MODEL_VALUE_RE.finditer(line):
-        value = match.group(1) or match.group(2)
+        value = next((g for g in match.groups() if g), None)
         if value:
             models.append(value)
     return models

--- a/tests/test_sarvam_rules.py
+++ b/tests/test_sarvam_rules.py
@@ -30,6 +30,15 @@ class TestRulesFile:
         line = 'data = {"model": "sarvam-105b", "messages": []}'
         assert extract_models(line) == ["sarvam-105b"]
 
+    def test_extract_models_unquoted_ts_key(self) -> None:
+        # Next.js / TS object literals often omit quotes on the key.
+        assert extract_models('  model: "sarvam-30b",') == ["sarvam-30b"]
+        assert extract_models("\tmodel: 'sarvam-105b'") == ["sarvam-105b"]
+
+    def test_extract_models_ignores_unrelated_identifiers(self) -> None:
+        # Avoid matching fields like `chat_model: "..."` via bare `model:`.
+        assert extract_models('chat_model: "sarvam-30b"') == []
+
 
 class TestAllowlistValidation:
     def test_deprecated_model_is_error_in_strict_mode(self) -> None:
@@ -52,6 +61,14 @@ class TestAllowlistValidation:
         issues = scan_added_lines_for_allowlist(
             Path("examples/new-recipe/app.py"),
             [(5, 'model = "sarvam-30b"')],
+            strict=True,
+        )
+        assert any(i.check == "deprecated-model" and i.severity == "error" for i in issues)
+
+    def test_ts_object_literal_deprecated_model_is_error(self) -> None:
+        issues = scan_added_lines_for_allowlist(
+            Path("examples/new-recipe/app.ts"),
+            [(12, '  model: "sarvam-30b",')],
             strict=True,
         )
         assert any(i.check == "deprecated-model" and i.severity == "error" for i in issues)


### PR DESCRIPTION
## Summary

PR CI allowlist scanning missed TypeScript/JavaScript object literals that use an unquoted `model` key (`model: "sarvam-30b"`). Deprecated chat models could therefore land in TS recipes without a strict-mode `deprecated-model` error.

## Changes

- Extend `MODEL_VALUE_RE` in `scripts/sarvam_rules.py` to match unquoted `model: "..."` keys (with a lookbehind so `chat_model:` is ignored)
- Add unit coverage in `tests/test_sarvam_rules.py`

## Security checklist

- [x] No real API keys in code, notebooks, configs, comments, or PR description
- [x] `SARVAM_API_KEY` is loaded from the environment — not hardcoded
- [x] N/A for `.env` (CI script change only)

## Test plan

- [x] `pytest tests/test_sarvam_rules.py -v` → 14 passed
- [x] Confirmed `extract_models('  model: "sarvam-30b",') == ['sarvam-30b']`
- [x] Confirmed `chat_model: "..."` is not matched

## Related issues

Helps keep cookbook examples aligned with the `sarvam-105b` allowlist (see also discussion on #113).