### PR TITLE
fix(tts): TTS convert() param is language_code, not target_language_code

### DIFF
--- a/examples/Realtime_Speech_Captioning/Realtime_Speech_Captioning.ipynb
+++ b/examples/Realtime_Speech_Captioning/Realtime_Speech_Captioning.ipynb
@@ -126,7 +126,7 @@
     "def synthesize(text: str, filename: str, language_code: str = \"hi-IN\") -> Path:\n",
     "    response = client.text_to_speech.convert(\n",
     "        text=text,\n",
-    "        target_language_code=language_code,\n",
+    "        language_code=language_code,\n",
     "        speaker=\"shubh\",\n",
     "        model=\"bulbul:v3\",\n",
     "    )\n",

--- a/examples/tts/book__summary_narrator.ipynb
+++ b/examples/tts/book__summary_narrator.ipynb
@@ -311,7 +311,7 @@
         "        logging.info(f\"Sending text of length {len(text)} to Sarvam TTS\")\n",
         "        response = client.text_to_speech.convert(\n",
         "            text=text,\n",
-        "            target_language_code=language_code,\n",
+        "            language_code=language_code,\n",
         "            speaker=\"shubh\",\n",
         "            model=\"bulbul:v3\",\n",
         "        )\n",

--- a/getting-started/tts/TTS_Tutorial.ipynb
+++ b/getting-started/tts/TTS_Tutorial.ipynb
@@ -128,7 +128,7 @@
         "|-----------|------|-------------|---------------|\n",
         "| `text` | string | Text to convert to speech (max 2500 chars for v3) | Required |\n",
         "| `model` | string | TTS model to use | `bulbul:v3` (latest), `bulbul:v2` (legacy) |\n",
-        "| `target_language_code` | string | Output language in BCP-47 format | `en-IN`, `hi-IN`, `bn-IN`, `ta-IN`, `te-IN`, `gu-IN`, `kn-IN`, `ml-IN`, `mr-IN`, `pa-IN`, `od-IN` |\n",
+        "| `language_code` | string | Output language in BCP-47 format | `en-IN`, `hi-IN`, `bn-IN`, `ta-IN`, `te-IN`, `gu-IN`, `kn-IN`, `ml-IN`, `mr-IN`, `pa-IN`, `od-IN` |\n",
         "| `speaker` | string | Voice speaker to use | See speakers below |\n",
         "| `pace` | float | Speech rate | 0.5 to 2.0 (default: 1.0) |\n",
         "| `temperature` | float | Controls expressiveness and randomness | 0.01 to 2.0 (default: 0.6) |\n",
@@ -150,7 +150,7 @@
       "source": [
         "response = client.text_to_speech.convert(\n",
         "    text=text,\n",
-        "    target_language_code=\"hi-IN\",\n",
+        "    language_code=\"hi-IN\",\n",
         "    model=\"bulbul:v3\",\n",
         "    speaker=\"shubh\",\n",
         "    pace=1.0,\n",


### PR DESCRIPTION
## Summary

`sarvamai` 0.1.29 renamed the text-to-speech REST parameter `target_language_code` →
`language_code`. Three recipes still pass the old name to
`client.text_to_speech.convert()`, which now raises `TypeError` **before any network call**.

From the 0.1.30 wheel:

```python
# sarvamai/text_to_speech/client.py:36
def convert(self, *, text: str, language_code: TextToSpeechLanguage, speaker=..., ...)

# sarvamai/text_to_speech/raw_client.py:173
json={"text": text, "language_code": language_code, ...}
```

`target_language_code` is gone from both `convert()` and `convert_stream()`. The npm
`sarvamai` package made the same change in 1.1.8. Sarvam's docs agree — every TTS example on
[the Bulbul page](https://docs.sarvam.ai/api/getting-started/models/bulbul) and the
[REST API guide](https://docs.sarvam.ai/api/api-guides-tutorials/text-to-speech/rest-api)
uses `language_code`.

**This breaks a shipped recipe today, per its own pin.**
`examples/Realtime_Speech_Captioning/requirements.txt` declares `sarvamai>=0.1.28` with no
upper bound, so `pip install -r requirements.txt` resolves 0.1.30 and the notebook fails on
its first TTS cell.

## Changes

| File | Change |
|------|--------|
| `getting-started/tts/TTS_Tutorial.ipynb` | parameter table row + the `convert()` call |
| `examples/tts/book__summary_narrator.ipynb` | the `convert()` call |
| `examples/Realtime_Speech_Captioning/Realtime_Speech_Captioning.ipynb` | the `convert()` call |

4 lines across 3 files. No behavior change beyond the corrected keyword.

**Deliberately left alone** — these are *not* the same bug:

- `integrations/build_voice_agent_with_livekit.ipynb` — `livekit-plugins-sarvam`'s
  `sarvam.TTS()` genuinely takes `target_language_code`.
- `integrations/build_voice_agent_with_{pipecat,twilio,exotel}.ipynb` — these pass it inside
  `Settings(...)`, where `SarvamTTSSettings._aliases = {"target_language_code": "language"}`
  makes it a valid alias. Those notebooks already say so in prose.
- `examples/Indic Soundbox AI/modules/tts.py` and
  `examples/sarvam-podcast-generator/inngest/podcast-generation.ts` — these `POST` hand-built
  JSON to `api.sarvam.ai/text-to-speech` rather than going through the SDK. Whether the
  **wire** API still accepts the legacy field name is something I could not verify without a
  live key, so I did not touch them. Happy to follow up if a maintainer can confirm.

## Security checklist

- [x] No real API keys in code, notebooks, configs, comments, or PR description
- [x] `SARVAM_API_KEY` still loaded from the environment — unchanged by this PR
- [x] N/A for `.env` (no dependency or config changes)
- [x] Notebook outputs untouched; only `source` lines edited, no re-serialization

## Test plan

- [x] `make check` → **PASS — 0 error(s), 0 warning(s)**; `pytest tests/` 82 passed;
      `sync_sarvam_rules.py --check` up to date; `ci_validate.py` clean
- [x] Reproduced the failure and the fix against `sarvamai==0.1.30` with a dummy key:

  ```
  BEFORE  TypeError: TextToSpeechClient.convert() got an unexpected
          keyword argument 'target_language_code'
  AFTER   ForbiddenError: ...          # reaches the API, rejected on the dummy key
  ```

  Before the change it fails locally on the signature; after, it gets far enough to be
  refused on auth — which is the expected result without a real key.
- [x] `git diff` confirms 4 changed lines and no notebook JSON churn

## Related issues

Same deprecation-drift family as #113 (`sarvam-30b` vs the allowlist) — different API surface.
