### PR TITLE
chore(rules): allow saaras:v3-realtime for the streaming STT endpoint

### DIFF
--- a/scripts/sarvam_api_rules.json
+++ b/scripts/sarvam_api_rules.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "synced_at": "2026-07-27T07:01:30Z",
+  "synced_at": "2026-08-06T07:55:33Z",
   "docs_url": "https://docs.sarvam.ai",
   "min_sarvamai_version": "0.1.24",
   "models": {
@@ -18,7 +18,8 @@
     },
     "stt": {
       "allowed": [
-        "saaras:v3"
+        "saaras:v3",
+        "saaras:v3-realtime"
       ],
       "recommended": [
         "saaras:v3"

--- a/scripts/sync_sarvam_rules.py
+++ b/scripts/sync_sarvam_rules.py
@@ -47,7 +47,10 @@ def canonical_rules() -> dict:
                 "deprecated": ["sarvam-m", "sarvam-30b"],
             },
             "stt": {
-                "allowed": ["saaras:v3"],
+                # saaras:v3-realtime powers the WebSocket streaming endpoint
+                # (wss://api.sarvam.ai/speech-to-text-realtime/ws) and is currently
+                # beta-gated per docs.sarvam.ai/api-reference/beta-apis.
+                "allowed": ["saaras:v3", "saaras:v3-realtime"],
                 "recommended": ["saaras:v3"],
                 "deprecated": ["saarika:v2.5", "saarika:v2"],
             },


### PR DESCRIPTION
## Summary

Adds `saaras:v3-realtime` to the STT allowlist in `scripts/sync_sarvam_rules.py` and regenerates `scripts/sarvam_api_rules.json`.

The model is already used on `main` at `examples/Realtime_Speech_Captioning/app.py:67`, but it is absent from the allowlist, so `scan_added_lines_for_allowlist()` reports it as an unknown model:

```python
>>> scan_added_lines_for_allowlist(Path("app.py"), [(1, '"model": "saaras:v3-realtime",')], strict=False)
[Issue(severity='warning', check='unknown-model', ...)]
```

This has no effect today because the allowlist scanners are not currently invoked by CI (#121). It becomes relevant as soon as they are: any PR editing the realtime captioning example would be flagged against the repository's own streaming example.

It is added to `allowed` but deliberately not to `recommended`, since the realtime model is beta-gated behind `enable_saaras_v3_realtime_streaming_users` (noted in `examples/Realtime_Speech_Captioning/app.py:25`) and should not be suggested as the default for new recipes.

Changes are made in `canonical_rules()` rather than by editing the generated JSON directly, so the weekly sync job does not revert them.

## Security checklist (required)

- [x] No real API keys in code, notebooks, configs, comments, or PR description
- [x] `SARVAM_API_KEY` is loaded from the environment — not hardcoded
- [x] `.env` is gitignored (new recipes must include `.env.example`)

## New notebook recipe? (if applicable)

Not applicable — this PR only touches `scripts/`.

## Test plan

Verified locally:

```
python scripts/sync_sarvam_rules.py --verbose   # regenerates the JSON
python scripts/sync_sarvam_rules.py --check     # sarvam_api_rules.json is up to date
python -m pytest tests/ -q                      # 82 passed
```

The two checkboxes below are not applicable: this change adds no API calls, so there is nothing to run against a live key.

- [ ] Ran the example locally with a valid `SARVAM_API_KEY` — n/a, no API calls in this change
- [x] Confirmed no secrets in `git diff` after running

## Related issues

Related to #121 — that issue proposes invoking the allowlist scanners from CI. This PR is worth landing first so that enabling those checks does not immediately flag `examples/Realtime_Speech_Captioning`.
