### PR TITLE
fix(ci): invoke model allowlist and deprecated-API scanners on PR diffs

### DIFF
--- a/scripts/ci_validate.py
+++ b/scripts/ci_validate.py
@@ -52,9 +52,11 @@ def changed_recipe_dirs(base_ref: str, head_ref: str = "HEAD") -> list[Path]:
     return []
 
 
-def run_validation(base_ref: str, head_ref: str = "HEAD") -> list[Issue]:
+def run_validation(
+    base_ref: str, head_ref: str = "HEAD", *, strict: bool = False
+) -> list[Issue]:
     issues: list[Issue] = []
-    issues.extend(validate_pr_with_refs(base_ref, head_ref))
+    issues.extend(validate_pr_with_refs(base_ref, head_ref, strict=strict))
     for recipe_dir in changed_recipe_dirs(base_ref, head_ref):
         issues.extend(validate_recipe(REPO_ROOT / recipe_dir))
     return issues
@@ -65,9 +67,14 @@ def main() -> int:
     parser.add_argument("--base-ref", default="main")
     parser.add_argument("--head-ref", default="HEAD")
     parser.add_argument("--output", help="Write JSON issues to this file")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Report model allowlist and deprecated-API findings as errors.",
+    )
     args = parser.parse_args()
 
-    issues = run_validation(args.base_ref, args.head_ref)
+    issues = run_validation(args.base_ref, args.head_ref, strict=args.strict)
     payload = [_issue_dict(i) for i in issues]
     errors = [i for i in issues if i.severity == "error"]
 

--- a/scripts/sarvam_checks.py
+++ b/scripts/sarvam_checks.py
@@ -72,6 +72,32 @@ SCAN_SKIP_NAMES = frozenset({".gitkeep", "package-lock.json"})
 
 LEGACY_EXAMPLE_DIRS = frozenset({"TEMPLATE"})
 
+# Endpoints superseded on docs.sarvam.ai, as (pattern, message, check) triples.
+# Consumed by scan_added_lines_for_deprecated_api(). Patterns are matched against
+# individual added lines, so pre-existing usage on main is untouched until edited.
+DEPRECATED_API_RULES: tuple[tuple[re.Pattern[str], str, str], ...] = (
+    (
+        re.compile(r"wss://api\.sarvam\.ai/speech-to-text(?!-realtime)"),
+        "Legacy STT WebSocket endpoint — use wss://api.sarvam.ai/speech-to-text-realtime/ws",
+        "legacy-endpoint",
+    ),
+    (
+        re.compile(r"api\.sarvam\.ai/speech-to-text-translate\b"),
+        'Legacy speech-to-text-translate endpoint — use /speech-to-text with mode="translate"',
+        "legacy-endpoint",
+    ),
+    (
+        re.compile(r"api\.sarvam\.ai/document-intelligence\b"),
+        "Legacy Document Intelligence endpoint — use /doc-ai/v1/job/*",
+        "legacy-endpoint",
+    ),
+    (
+        re.compile(r"api\.sarvam\.ai/speech-to-text/job/(?!v1\b)"),
+        "Unversioned batch speech-to-text job path — use /speech-to-text/job/v1/...",
+        "legacy-endpoint",
+    ),
+)
+
 
 # ---------------------------------------------------------------------------
 # Path helpers

--- a/scripts/validate_pr.py
+++ b/scripts/validate_pr.py
@@ -23,9 +23,13 @@ from pathlib import Path
 
 from sarvam_checks import (
     Issue,
+    git_diff_added_lines,
     git_diff_name_only,
+    scan_added_lines_for_allowlist,
+    scan_added_lines_for_deprecated_api,
     scan_file_for_client_side_keys,
     scan_file_for_secrets,
+    should_scan_file,
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -41,8 +45,14 @@ def changed_paths(base_ref: str, head_ref: str = "HEAD") -> list[Path]:
     return paths
 
 
-def validate_pr_with_refs(base_ref: str, head_ref: str = "HEAD") -> list[Issue]:
-    """Run PR-scoped secret checks between base_ref and head_ref."""
+def validate_pr_with_refs(
+    base_ref: str, head_ref: str = "HEAD", *, strict: bool = False
+) -> list[Issue]:
+    """Run PR-scoped secret and Sarvam API compliance checks.
+
+    Model allowlist and deprecated-endpoint checks run against added lines only,
+    so pre-existing usage elsewhere in a touched file is not reported.
+    """
     issues: list[Issue] = []
     changed = changed_paths(base_ref, head_ref)
     if not changed:
@@ -57,12 +67,22 @@ def validate_pr_with_refs(base_ref: str, head_ref: str = "HEAD") -> list[Issue]:
         issues.extend(scan_file_for_secrets(full, REPO_ROOT))
         issues.extend(scan_file_for_client_side_keys(full))
 
+        if should_scan_file(full):
+            added = git_diff_added_lines(base_ref, str(rel), head_ref)
+            if added:
+                issues.extend(
+                    scan_added_lines_for_allowlist(rel, added, strict=strict)
+                )
+                issues.extend(
+                    scan_added_lines_for_deprecated_api(rel, added, strict=strict)
+                )
+
     return issues
 
 
-def validate_pr(base_ref: str) -> list[Issue]:
-    """Run PR-scoped secret checks on changed files."""
-    return validate_pr_with_refs(base_ref, "HEAD")
+def validate_pr(base_ref: str, *, strict: bool = False) -> list[Issue]:
+    """Run PR-scoped secret and API compliance checks on changed files."""
+    return validate_pr_with_refs(base_ref, "HEAD", strict=strict)
 
 
 def main() -> int:
@@ -86,7 +106,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    issues = validate_pr(args.base_ref)
+    issues = validate_pr(args.base_ref, strict=args.strict)
     errors = [i for i in issues if i.severity == "error"]
     warnings = [i for i in issues if i.severity == "warning"]
 

--- a/tests/test_sarvam_rules.py
+++ b/tests/test_sarvam_rules.py
@@ -9,7 +9,11 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from sarvam_checks import scan_added_lines_for_allowlist  # noqa: E402
+from sarvam_checks import (  # noqa: E402
+    DEPRECATED_API_RULES,
+    scan_added_lines_for_allowlist,
+    scan_added_lines_for_deprecated_api,
+)
 from sarvam_rules import (  # noqa: E402
     extract_models,
     get_rules,
@@ -121,3 +125,62 @@ class TestAllowlistValidation:
         path.write_text(json.dumps(stale, indent=2) + "\n")
         _, needs_sync = sync_rules()
         assert needs_sync is True
+
+
+class TestDeprecatedApiRules:
+    """DEPRECATED_API_RULES was referenced but never defined; see issue."""
+
+    def test_rules_are_defined(self) -> None:
+        assert DEPRECATED_API_RULES
+
+    def test_scan_runs_without_error(self) -> None:
+        # Previously raised NameError on the first non-comment line.
+        assert scan_added_lines_for_deprecated_api(
+            Path("app.py"), [(1, "x = 1")], strict=False
+        ) == []
+
+    def test_legacy_stt_websocket_flagged(self) -> None:
+        issues = scan_added_lines_for_deprecated_api(
+            Path("app.py"),
+            [(1, 'WS = "wss://api.sarvam.ai/speech-to-text"')],
+            strict=False,
+        )
+        assert [i.check for i in issues] == ["legacy-endpoint"]
+
+    def test_realtime_websocket_not_flagged(self) -> None:
+        # examples/Realtime_Speech_Captioning/app.py uses this on main.
+        assert scan_added_lines_for_deprecated_api(
+            Path("app.py"),
+            [(1, 'WS = "wss://api.sarvam.ai/speech-to-text-realtime/ws"')],
+            strict=False,
+        ) == []
+
+    def test_versioned_batch_path_not_flagged(self) -> None:
+        assert scan_added_lines_for_deprecated_api(
+            Path("app.py"),
+            [(1, 'url = "https://api.sarvam.ai/speech-to-text/job/v1/init"')],
+            strict=False,
+        ) == []
+
+    def test_unversioned_batch_path_flagged(self) -> None:
+        issues = scan_added_lines_for_deprecated_api(
+            Path("app.py"),
+            [(1, 'url = "https://api.sarvam.ai/speech-to-text/job/init"')],
+            strict=False,
+        )
+        assert [i.check for i in issues] == ["legacy-endpoint"]
+
+    def test_strict_promotes_to_error(self) -> None:
+        issues = scan_added_lines_for_deprecated_api(
+            Path("app.py"),
+            [(1, 'WS = "wss://api.sarvam.ai/speech-to-text"')],
+            strict=True,
+        )
+        assert [i.severity for i in issues] == ["error"]
+
+    def test_comments_are_skipped(self) -> None:
+        assert scan_added_lines_for_deprecated_api(
+            Path("app.py"),
+            [(1, '# wss://api.sarvam.ai/speech-to-text is legacy')],
+            strict=False,
+        ) == []


### PR DESCRIPTION
## Summary

Fixes #121.

`scan_added_lines_for_allowlist()` and `scan_added_lines_for_deprecated_api()` exist in `scripts/sarvam_checks.py` but are never called from the CI path, so `scripts/sarvam_api_rules.json` is enforced only by unit tests. A PR introducing a deprecated model currently passes validation.

This PR wires both scanners into `validate_pr_with_refs()` and defines the missing `DEPRECATED_API_RULES` constant.

### Changes

**`scripts/sarvam_checks.py`** — defines `DEPRECATED_API_RULES`, referenced at line 302 but not defined anywhere in the repository (calling `scan_added_lines_for_deprecated_api()` raised `NameError`). Covers four endpoint families currently filed under Legacy in the API reference:

- legacy STT WebSocket (`wss://api.sarvam.ai/speech-to-text`, excluding `speech-to-text-realtime`)
- `/speech-to-text-translate`
- `/document-intelligence`
- unversioned `/speech-to-text/job/` paths

**`scripts/validate_pr.py`** — calls both scanners over `git_diff_added_lines()` for changed files under `examples/` and `getting-started/`. Adds a `strict` parameter, default `False`. Also fixes a latent bug: `main()` parsed `--strict` but never passed it to `validate_pr()`.

**`scripts/ci_validate.py`** — threads `strict` through `run_validation()` and exposes `--strict`.

**`tests/test_sarvam_rules.py`** — eight tests covering the constant, the previously crashing call path, strict promotion, comment skipping, and two negative cases.

### On severity

These findings are reported as **warnings** by default, not errors. Enabling them at error level would immediately fail open PRs that touch model strings. Warnings surface the signal without a flag day; maintainers can promote them via the existing `--strict` flag once the tree is clean. Happy to flip the default if you would rather have it blocking from the start.

### Scope

Checks run against **added lines only**, so existing content is unaffected until a file is edited. Two deliberate negative tests confirm `wss://api.sarvam.ai/speech-to-text-realtime/ws` and `/speech-to-text/job/v1/` are not flagged.

Note that with this enabled, `saaras:v3-realtime` in `examples/Realtime_Speech_Captioning/app.py` reports as `unknown-model`, since it is missing from the allowlist. #122 adds it. Merging that first avoids the warning; this PR does not depend on it.

## Security checklist (required)

- [x] No real API keys in code, notebooks, configs, comments, or PR description
- [x] `SARVAM_API_KEY` is loaded from the environment — not hardcoded
- [x] `.env` is gitignored (new recipes must include `.env.example`)

## New notebook recipe? (if applicable)

Not applicable — this PR only touches `scripts/` and `tests/`.

## Test plan

```
python -m pytest tests/ -q                    # 90 passed (82 before)
python scripts/sync_sarvam_rules.py --check   # up to date
```

End-to-end, appending a deprecated model and a legacy WebSocket URL to an example:

| Mode | Result |
|---|---|
| default | 2 warnings, exit 0 |
| `--strict` | 2 errors, exit 1 |

Before this change the same diff reported `PASS — 0 error(s), 0 warning(s)`.

False-positive check: a commit adding `saaras:v3` and `wss://api.sarvam.ai/speech-to-text-realtime/ws` produces no findings.

- [ ] Ran the example locally with a valid `SARVAM_API_KEY` — n/a, this change makes no API calls
- [x] Confirmed no secrets in `git diff` after running

## Related issues

Fixes #121. Related to #122.
