### PR TITLE
fix(ci): catch hardcoded keys spelled api-subscription-key

### DIFF
--- a/scripts/validate_recipe.py
+++ b/scripts/validate_recipe.py
@@ -55,13 +55,16 @@ _MIN_PILLOW_VERSION = Version("12.1.1")
 
 # Matches hardcoded keys of the form:
 #   SARVAM_API_KEY = "real-value"   or   api_subscription_key="real-value"
+# The separators in api-subscription-key are optional so that the hyphenated
+# spelling of Sarvam's auth header — the form REST recipes actually write —
+# is caught too. Kept in sync with SECRET_ASSIGNMENT_RE in sarvam_checks.py.
 # Does NOT match:
-#   YOUR_SARVAM_API_KEY, your_key, <your …>, your-key (placeholder patterns)
+#   YOUR_SARVAM_API_KEY, your-sarvam-api-key, your_key, your-key, <your …>
 #   Unquoted references such as api_subscription_key=SARVAM_API_KEY
 #   os.environ.get(...) assignments
 _SECRET_RE = re.compile(
-    r"(?:SARVAM_API_KEY|api_subscription_key)\s*=\s*"
-    r"""[\"'](?!YOUR_SARVAM|your_key|<your|your-key)[^\"']{10,}[\"']""",
+    r"(?:SARVAM_API_KEY|api[_-]?subscription[_-]?key)\s*=\s*"
+    r"""[\"'](?!YOUR[_-]?SARVAM|your[_-]?key|<your)[^\"']{10,}[\"']""",
     re.IGNORECASE,
 )
 

--- a/tests/test_validate_recipe.py
+++ b/tests/test_validate_recipe.py
@@ -378,6 +378,25 @@ class TestSecrets:
         )
         assert any(i.check == "secrets" for i in _errors(check_secrets(d)))
 
+    def test_hyphenated_subscription_key_flagged(self, tmp_path: Path) -> None:
+        # api-subscription-key is the spelling of Sarvam's auth header, so it is
+        # what REST recipes write; a key hardcoded that way must still be caught.
+        d = _make_recipe(tmp_path)
+        (d / "helper.py").write_text(
+            'api-subscription-key = "a-real-subscription-key-1234567890"\n',
+            encoding="utf-8",
+        )
+        assert any(i.check == "secrets" for i in _errors(check_secrets(d)))
+
+    def test_hyphenated_placeholder_not_flagged(self, tmp_path: Path) -> None:
+        # your-sarvam-api-key is the placeholder auto_fix() writes into
+        # .env.example; quoting it in a notebook or README is not a leak.
+        d = _make_recipe(tmp_path)
+        (d / "helper.py").write_text(
+            'SARVAM_API_KEY = "your-sarvam-api-key"\n', encoding="utf-8"
+        )
+        assert not _errors(check_secrets(d))
+
     def test_short_quoted_value_under_threshold_not_flagged(self, tmp_path: Path) -> None:
         # Values shorter than 10 characters cannot be real API keys.
         d = _make_recipe(tmp_path)


### PR DESCRIPTION
## Summary

`_SECRET_RE` in `scripts/validate_recipe.py` only matched the underscored
`api_subscription_key`, so a key hardcoded as `api-subscription-key = "..."` passed
`check_secrets()` silently. That hyphenated form is the spelling of Sarvam's auth
header, and it is what the REST recipes in this cookbook actually write — e.g.
`examples/Indic Soundbox AI/modules/tts.py`:

```python
headers = {
    'api-subscription-key': SARVAM_API_KEY,
    ...
}
```

Since `secrets` is a blocking (error-severity) check, the miss meant a hardcoded key
written in the form contributors are most likely to copy could merge.

The same lookahead also only excluded the underscored `YOUR_SARVAM` placeholder, so
`SARVAM_API_KEY = "your-sarvam-api-key"` — the placeholder `auto_fix()` itself writes
into `.env.example` — was reported as an **error** whenever a notebook or README quoted
it.

Both spellings are already handled correctly by `SECRET_ASSIGNMENT_RE` and
`PLACEHOLDER_KEY_PATTERNS` in `scripts/sarvam_checks.py`. This brings the standalone
recipe validator in line with the CI path rather than defining new policy:

| input | before | after |
|---|---|---|
| `api-subscription-key = "<real key>"` | missed | flagged |
| `api_subscription_key = "<real key>"` | flagged | flagged |
| `SARVAM_API_KEY = "your-sarvam-api-key"` | false positive | clean |
| `SARVAM_API_KEY = "YOUR_SARVAM_API_KEY"` | clean | clean |

`real-value` stays flagged, matching the documented behaviour of this module.

## Security checklist (required)

- [x] No real API keys in code, notebooks, configs, comments, or PR description
- [x] `SARVAM_API_KEY` is loaded from the environment — not hardcoded
- [x] `.env` is gitignored (new recipes must include `.env.example`)

## New notebook recipe? (if applicable)

Not applicable — no recipe added. Validator change only.

## Test plan

Two regression tests added to `tests/TestSecrets`, both verified to fail on the
unpatched regex and pass with it:

- `test_hyphenated_subscription_key_flagged`
- `test_hyphenated_placeholder_not_flagged`

```
$ pytest tests/ -q
84 passed
```

- `python scripts/sync_sarvam_rules.py --check` — passes
- `python scripts/ci_validate.py --base-ref main` — `PASS — 0 error(s), 0 warning(s)`
- Scanned every text file in the repo with the updated regex: zero new findings under
  `examples/` or `getting-started/`. The only matches are this module's own docstring
  examples and the test fixtures, which are intentional.
- No API key required; all checks are filesystem-based.

Checkboxes from the template that do not apply here:

- [ ] ~Ran the example locally with a valid `SARVAM_API_KEY`~ — no example changed
- [x] Confirmed no secrets in `git diff` after running

## Related issues

None — found while reading the validators. Does not overlap with #123, which touches
`ci_validate.py`, `sarvam_checks.py`, `validate_pr.py`, and `test_sarvam_rules.py`;
this PR touches only `validate_recipe.py` and `test_validate_recipe.py`.
