### PR TITLE
fix(validators): scan notebooks saved with a UTF-8 BOM for hardcoded API keys

### DIFF
--- a/scripts/sarvam_checks.py
+++ b/scripts/sarvam_checks.py
@@ -188,21 +188,34 @@ def git_diff_added_lines(base_ref: str, file_path: str, head_ref: str = "HEAD") 
 # ---------------------------------------------------------------------------
 
 
-def notebook_cell_sources(nb_path: Path) -> list[str]:
-    """Parse notebook JSON and return each cell's source text."""
+def load_notebook_cells(nb_path: Path) -> list[dict] | None:
+    """Parse notebook JSON and return its cell list, or None if unparseable.
+
+    Read as utf-8-sig so notebooks saved with a UTF-8 BOM (common on Windows)
+    parse normally instead of failing and being skipped by the callers.
+    """
     try:
         nb = json.loads(nb_path.read_text(encoding="utf-8-sig"))
     except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return None
+    cells = nb.get("cells")
+    return cells if isinstance(cells, list) else []
+
+
+def cell_source(cell: dict) -> str:
+    """Return a cell's source text, handling list-of-strings and plain string."""
+    src = cell.get("source", [])
+    if isinstance(src, list):
+        return "".join(src)
+    return str(src) if src else ""
+
+
+def notebook_cell_sources(nb_path: Path) -> list[str]:
+    """Parse notebook JSON and return each cell's source text."""
+    cells = load_notebook_cells(nb_path)
+    if not cells:
         return []
-    cells = nb.get("cells", [])
-    sources: list[str] = []
-    for cell in cells:
-        src = cell.get("source", [])
-        if isinstance(src, list):
-            sources.append("".join(src))
-        else:
-            sources.append(str(src) if src else "")
-    return sources
+    return [cell_source(cell) for cell in cells]
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/validate_recipe.py
+++ b/scripts/validate_recipe.py
@@ -30,6 +30,14 @@ from typing import NamedTuple
 
 from packaging.version import Version
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from sarvam_checks import (  # noqa: E402
+    SECRET_ASSIGNMENT_RE,
+    cell_source as _cell_source,
+    load_notebook_cells as _load_notebook_cells,
+)
+
 # ---------------------------------------------------------------------------
 # Data types
 # ---------------------------------------------------------------------------
@@ -53,17 +61,10 @@ _REQUIRED_GITIGNORE_PATTERNS: list[str] = [".env", "sample_data/*", "outputs/*"]
 _MIN_SARVAMAI_VERSION = Version("0.1.24")
 _MIN_PILLOW_VERSION = Version("12.1.1")
 
-# Matches hardcoded keys of the form:
-#   SARVAM_API_KEY = "real-value"   or   api_subscription_key="real-value"
-# Does NOT match:
-#   YOUR_SARVAM_API_KEY, your_key, <your …>, your-key (placeholder patterns)
-#   Unquoted references such as api_subscription_key=SARVAM_API_KEY
-#   os.environ.get(...) assignments
-_SECRET_RE = re.compile(
-    r"(?:SARVAM_API_KEY|api_subscription_key)\s*=\s*"
-    r"""[\"'](?!YOUR_SARVAM|your_key|<your|your-key)[^\"']{10,}[\"']""",
-    re.IGNORECASE,
-)
+# Hardcoded-key detection is shared with validate_pr via sarvam_checks so the
+# two entry points cannot drift apart. See SECRET_ASSIGNMENT_RE for the
+# placeholder patterns that are deliberately not matched.
+_SECRET_RE = SECRET_ASSIGNMENT_RE
 
 # Unicode blocks that cover the overwhelming majority of emoji characters.
 # Deliberately excludes Devanagari, Tamil, and other Indic script blocks so
@@ -102,42 +103,6 @@ def _notebook_name(recipe_dir: Path) -> str:
         Expected notebook filename (basename only, not a full path).
     """
     return recipe_dir.name.replace("-", "_") + ".ipynb"
-
-
-def _load_notebook_cells(nb_path: Path) -> list[dict] | None:
-    """Parse a Jupyter notebook JSON file and return its cell list.
-
-    Uses the stdlib json module; the notebook is never executed.
-
-    Args:
-        nb_path: Path to the .ipynb file.
-
-    Returns:
-        List of cell dicts, or None if the file cannot be parsed.
-    """
-    try:
-        nb = json.loads(nb_path.read_text(encoding="utf-8"))
-        cells = nb.get("cells")
-        return cells if isinstance(cells, list) else []
-    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
-        return None
-
-
-def _cell_source(cell: dict) -> str:
-    """Return the joined source text of a notebook cell.
-
-    Handles both list-of-strings and plain-string source formats.
-
-    Args:
-        cell: A Jupyter cell dict.
-
-    Returns:
-        The full source as a single string.
-    """
-    src = cell.get("source", [])
-    if isinstance(src, list):
-        return "".join(src)
-    return str(src) if src else ""
 
 
 # ---------------------------------------------------------------------------
@@ -307,6 +272,13 @@ def check_secrets(recipe_dir: Path) -> list[Issue]:
         if fp.suffix == ".ipynb":
             cells = _load_notebook_cells(fp)
             if cells is None:
+                # Never skip silently: an unreadable notebook is a notebook
+                # whose cells were not scanned for keys.
+                issues.append(Issue(
+                    "error", "secrets",
+                    f"Cannot parse notebook, so it was not scanned for API keys: {rel}",
+                    "Ensure the notebook is valid JSON (open it in Jupyter to check).",
+                ))
                 continue
             for cell in cells:
                 if _SECRET_RE.search(_cell_source(cell)):

--- a/tests/test_validate_recipe.py
+++ b/tests/test_validate_recipe.py
@@ -396,6 +396,40 @@ class TestSecrets:
         (d / "sample_data" / "image.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"x" * 100)
         assert not _errors(check_secrets(d))
 
+    def test_hardcoded_key_in_bom_notebook_flagged(self, tmp_path: Path) -> None:
+        # A notebook saved with a UTF-8 BOM must still be scanned; previously
+        # the BOM made the parse fail and the notebook was skipped silently.
+        d = _make_recipe(tmp_path, "my-recipe")
+        nb_path = d / "my_recipe.ipynb"
+        nb = json.loads(nb_path.read_text(encoding="utf-8"))
+        nb["cells"].append({
+            "cell_type": "code",
+            "source": ['SARVAM_API_KEY = "sk-real-api-key-12345678901234"\n'],
+            "metadata": {},
+            "outputs": [],
+            "execution_count": None,
+        })
+        nb_path.write_text(json.dumps(nb), encoding="utf-8-sig")
+        assert nb_path.read_bytes().startswith(b"\xef\xbb\xbf")
+        assert any(i.check == "secrets" for i in _errors(check_secrets(d)))
+
+    def test_unparseable_notebook_reported_not_skipped(self, tmp_path: Path) -> None:
+        # An unscannable notebook must fail validation rather than pass it.
+        d = _make_recipe(tmp_path, "my-recipe")
+        (d / "my_recipe.ipynb").write_text("{not valid json", encoding="utf-8")
+        errors = _errors(check_secrets(d))
+        assert any(i.check == "secrets" and "Cannot parse" in i.message for i in errors)
+
+    def test_hyphenated_subscription_key_flagged(self, tmp_path: Path) -> None:
+        # api-subscription-key is the header spelling used by the Sarvam API and
+        # must be caught alongside the underscore form.
+        d = _make_recipe(tmp_path)
+        (d / "helper.py").write_text(
+            'api-subscription-key = "a-real-subscription-key-1234567890"\n',
+            encoding="utf-8",
+        )
+        assert any(i.check == "secrets" for i in _errors(check_secrets(d)))
+
 
 # ---------------------------------------------------------------------------
 # TestNotebookStructure


### PR DESCRIPTION
Fixes #126.

## The bug

`validate_recipe._load_notebook_cells()` read notebooks with `encoding="utf-8"`. Any `.ipynb` saved with a UTF-8 BOM — routine for editors on Windows — raised `json.JSONDecodeError: Unexpected UTF-8 BOM`, which the `except` clause swallowed into `None`. `check_secrets()` then treated `None` as "nothing to check":

```python
cells = _load_notebook_cells(fp)
if cells is None:
    continue   # notebook skipped entirely, no issue reported
```

So a notebook containing a real `SARVAM_API_KEY` passed validation clean as long as the file started with a BOM. The check that exists specifically to stop contributors committing live keys was the one failing open.

Not hypothetical — two notebooks already in the repo carry a BOM and were unparseable by `validate_recipe.py`:

- `getting-started/chat completion/Chat_Completion.ipynb`
- `getting-started/translate/Translate_API_Tutorial.ipynb`

## Root cause

Two independent notebook parsers that disagreed. `sarvam_checks.notebook_cell_sources()` already read `utf-8-sig` and handled this correctly; `validate_recipe.py` carried its own duplicated copy that did not.

Fixing only the encoding would leave the duplication that caused it, so this hoists the parser into `sarvam_checks` as `load_notebook_cells()` / `cell_source()` and points both callers at it. `validate_recipe.py` is net −35 lines.

## Changes

1. **Shared parser.** `load_notebook_cells()` and `cell_source()` now live in `sarvam_checks.py`, reading `utf-8-sig`. `notebook_cell_sources()` is expressed in terms of them; `validate_recipe.py` imports them and its duplicates are deleted.
2. **Fail closed, not open.** An unparseable notebook now reports a `secrets` error instead of being skipped — a notebook that could not be read is a notebook whose cells were never scanned, which is a finding, not a pass.
3. **Secret regex de-duplicated.** The same split had produced a second divergence: `validate_recipe`'s `_SECRET_RE` did not match the hyphenated `api-subscription-key` spelling the Sarvam API actually uses in its header, nor the `your_sarvam` / `real-value` placeholders. It now uses the shared `SECRET_ASSIGNMENT_RE`.

## Tests

Three regression tests added to `TestSecrets`, each verified to fail on `main` and pass here:

| Test | Guards against |
|---|---|
| `test_hardcoded_key_in_bom_notebook_flagged` | the reported bug — key in a BOM-prefixed notebook |
| `test_unparseable_notebook_reported_not_skipped` | the fail-open `continue` returning |
| `test_hyphenated_subscription_key_flagged` | the regex divergence |

```
$ python -m pytest tests/ -q
85 passed

$ python scripts/sync_sarvam_rules.py --check
sarvam_api_rules.json is up to date.

$ python scripts/ci_validate.py --base-ref main
PASS — 0 error(s), 0 warning(s)
```

Both previously-unparseable notebooks now parse (22 and 55 cells). No notebook content was modified — the BOMs are left in place, since the validator should tolerate them rather than the files being rewritten to suit it.
