### PR TITLE
fix(ci): deliver validation feedback to fork PRs via workflow_run

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,6 +1,12 @@
 name: PR Check
 
-# Validates contributor PRs and posts actionable comments on failure.
+# Validates contributor PRs and emits an actionable report.
+#
+# This workflow runs untrusted PR code paths, so it holds a read-only token and
+# never comments itself: on a `pull_request` event from a fork GitHub issues a
+# read-only GITHUB_TOKEN no matter what `permissions:` asks for. The report is
+# written to the run summary and uploaded as an artifact; the companion
+# pr-comment.yml workflow picks it up and posts it.
 
 on:
   pull_request:
@@ -12,11 +18,11 @@ on:
       - "tests/**"
       - "requirements-dev.txt"
       - ".github/workflows/pr-check.yml"
+      - ".github/workflows/pr-comment.yml"
       - "scripts/sarvam_api_rules.json"
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   validate:
@@ -48,16 +54,30 @@ jobs:
           python scripts/ci_validate.py --base-ref "$BASE_REF" --output validation-results.json
         continue-on-error: true
 
-      - name: Post validation summary on failure
+      - name: Render validation report
         if: steps.validate.outcome == 'failure'
         env:
-          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          python scripts/pr_comment.py \
-            --input validation-results.json \
-            --output pr-comment.md
-          gh pr comment "${{ github.event.pull_request.number }}" \
-            --body-file pr-comment.md
+          python scripts/pr_comment.py --input validation-results.json --output pr-comment.md
+          # Carried in the artifact because github.event.workflow_run.pull_requests
+          # is empty for fork PRs.
+          echo "$PR_NUMBER" > pr-number.txt
+
+      - name: Add report to run summary
+        if: steps.validate.outcome == 'failure'
+        run: cat pr-comment.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report for the comment workflow
+        if: steps.validate.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-report
+          path: |
+            pr-comment.md
+            pr-number.txt
+            validation-results.json
+          if-no-files-found: error
 
       - name: Fail if validation failed
         if: steps.validate.outcome == 'failure'

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,60 @@
+name: PR Check Comment
+
+# Posts the report produced by pr-check.yml back onto the pull request.
+#
+# pr-check.yml runs on `pull_request`, which for a fork PR gets a read-only
+# GITHUB_TOKEN and therefore cannot comment. `workflow_run` runs in the base
+# repository's context with a writable token, and — unlike pull_request_target
+# — never checks out or executes the contributor's code. This job only ever
+# handles the rendered markdown artifact.
+
+on:
+  workflow_run:
+    workflows: ["PR Check"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    name: Post validation report
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download validation report
+        id: download
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: validation-report
+          path: report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # The run can fail before validation produces a report — a failing unit
+      # test, for instance. There is nothing to post in that case.
+      - name: Check report is present
+        id: check
+        run: |
+          if [ -s report/pr-comment.md ] && [ -s report/pr-number.txt ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No validation report artifact; nothing to comment."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post report as a PR comment
+        if: steps.check.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          pr_number=$(tr -cd '0-9' < report/pr-number.txt)
+          if [ -z "$pr_number" ]; then
+            echo "::error::pr-number.txt did not contain a PR number."
+            exit 1
+          fi
+          gh pr comment "$pr_number" --repo "$REPO" --body-file report/pr-comment.md


### PR DESCRIPTION
Fixes #127.

## The bug

`pr-check.yml` runs on `pull_request` and declares `pull-requests: write`. For a `pull_request` event raised **from a fork**, GitHub issues a read-only `GITHUB_TOKEN` regardless of what the `permissions:` block asks for — the grant is silently ignored. So this step 403s for every external contributor:

```yaml
gh pr comment "${{ github.event.pull_request.number }}" --body-file pr-comment.md
```

On a public cookbook that is effectively every contributor. `scripts/pr_comment.py` exists solely to render actionable remediation guidance, and it never reached the people it was written for: they saw a red X on a job whose comment step had also errored, and had to open the raw Actions log to find out what actually failed.

## The fix

Separate producing the report from posting it.

**`pr-check.yml`** keeps its read-only token and no longer tries to comment. It renders the report, writes it to `$GITHUB_STEP_SUMMARY`, and uploads it as an artifact. `pull-requests: write` is dropped, since it was never granted in practice.

**`pr-comment.yml`** (new) runs on `workflow_run: completed`. That executes in the base repository's context with a genuinely writable token, downloads the artifact, and posts the comment.

`workflow_run` rather than `pull_request_target`: the latter runs the fork's code with a writable token, which is a well-known privilege-escalation pattern. This job only ever downloads a rendered markdown artifact — it never checks out or executes contributor code, and needs no `contents: write`.

## Details worth reviewing

- **PR number travels in the artifact.** `github.event.workflow_run.pull_requests` is empty for fork PRs, so the number cannot be recovered from the event payload. `pr-check.yml` writes `pr-number.txt`; the comment job sanitises it with `tr -cd '0-9'` and fails loudly if it is empty.
- **Runs that fail before validation.** A failing unit test also produces `conclusion == 'failure'` and no report artifact. The download is `continue-on-error`, and a guard step checks for the files and exits quietly when there is nothing to post — no misleading empty comment.
- **Rendering and posting are separate steps**, as the issue asked. Previously both ran in one `run:` block, so a `pr_comment.py` crash was indistinguishable from a token permission error in the log.
- **The run summary is a second, independent path.** `$GITHUB_STEP_SUMMARY` needs no token at all and renders on the run page itself, so the report is visible even if the comment workflow is misconfigured. It costs one line.
- **`pr-comment.yml` added to the `paths:` filter** so changes to the comment workflow are themselves validated.

## Verification

Workflow YAML parses, and the report pipeline was dry-run locally against synthetic validation output:

```
$ python scripts/pr_comment.py --input issues.json --output pr-comment.md
## Cookbook validation failed
...
**1 blocking issue(s):**
### secrets
- Possible hardcoded API key in: helper.py
  - *Fix:* Load it from the environment.

$ python -m pytest tests/ -q
82 passed

$ python scripts/sync_sarvam_rules.py --check
sarvam_api_rules.json is up to date.
```

The permission behaviour itself can only be confirmed on a real fork PR — by construction it cannot be reproduced from a branch in the base repo, where the token is writable either way.

## Not included

The two workflows must agree on the artifact name and the three filenames inside it. A test asserting that would need PyYAML added to `requirements-dev.txt`; that seemed worth raising separately rather than folding a new dependency into a CI permissions fix. Happy to add it if you would prefer it here.
