### PR TITLE
fix(validators): validate every example directory, not just the two that opted in

### DIFF
--- a/scripts/ci_validate.py
+++ b/scripts/ci_validate.py
@@ -17,7 +17,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from sarvam_checks import Issue, is_recipe_directory  # noqa: E402
+from sarvam_checks import Issue, is_example_directory  # noqa: E402
 from validate_pr import validate_pr_with_refs  # noqa: E402
 from validate_recipe import validate_recipe  # noqa: E402
 
@@ -31,7 +31,7 @@ def _issue_dict(issue: Issue) -> dict:
     }
 
 
-def changed_recipe_dirs(base_ref: str, head_ref: str = "HEAD") -> list[Path]:
+def changed_example_dirs(base_ref: str, head_ref: str = "HEAD") -> list[Path]:
     for ref_pair in (f"origin/{base_ref}...{head_ref}", f"{base_ref}...{head_ref}"):
         result = subprocess.run(
             ["git", "diff", "--name-only", ref_pair],
@@ -46,7 +46,7 @@ def changed_recipe_dirs(base_ref: str, head_ref: str = "HEAD") -> list[Path]:
             parts = path.strip().split("/")
             if len(parts) >= 2 and parts[0] == "examples" and parts[1] not in {"TEMPLATE", ""}:
                 candidate = REPO_ROOT / "examples" / parts[1]
-                if is_recipe_directory(candidate):
+                if is_example_directory(candidate):
                     dirs.add(f"examples/{parts[1]}")
         return sorted(Path(d) for d in dirs)
     return []
@@ -55,7 +55,7 @@ def changed_recipe_dirs(base_ref: str, head_ref: str = "HEAD") -> list[Path]:
 def run_validation(base_ref: str, head_ref: str = "HEAD") -> list[Issue]:
     issues: list[Issue] = []
     issues.extend(validate_pr_with_refs(base_ref, head_ref))
-    for recipe_dir in changed_recipe_dirs(base_ref, head_ref):
+    for recipe_dir in changed_example_dirs(base_ref, head_ref):
         issues.extend(validate_recipe(REPO_ROOT / recipe_dir))
     return issues
 

--- a/scripts/sarvam_checks.py
+++ b/scripts/sarvam_checks.py
@@ -78,20 +78,52 @@ LEGACY_EXAMPLE_DIRS = frozenset({"TEMPLATE"})
 # ---------------------------------------------------------------------------
 
 
-def is_recipe_directory(path: Path) -> bool:
-    """Return True for notebook recipe dirs under examples/ (not app-style examples).
+def is_example_directory(path: Path) -> bool:
+    """Return True for any example directory under examples/.
 
-    Apps may include `.env.example` but lack a main `.ipynb`; those are excluded.
+    Membership only. This deliberately does not inspect the directory's
+    contents: the checks a directory fails are exactly the checks that should
+    report on it, so using file presence as the entry condition makes those
+    checks unable to fire. `.env.example` in particular is itself a required
+    file, so gating on it meant a recipe missing one was never examined.
     """
     if path.parent.name != "examples" or not path.is_dir():
         return False
-    if path.name in LEGACY_EXAMPLE_DIRS:
+    return path.name not in LEGACY_EXAMPLE_DIRS
+
+
+def is_notebook_recipe(path: Path) -> bool:
+    """Return True for a directory that ships a notebook.
+
+    Selects which checks apply, not whether the directory is checked at all —
+    deliberately independent of where the directory sits, so the two decisions
+    stay separable. App-style examples (Next.js, Flask, Streamlit) have no
+    notebook and no sample_data/outputs, so the notebook-recipe structure rules
+    in CONTRIBUTING.md do not apply to them; the universal checks still do.
+    """
+    return path.is_dir() and any(path.glob("*.ipynb"))
+
+
+# Files that positively identify an app-style example. Membership must be
+# proven, never inferred from absence: "no notebook" alone would let a recipe
+# escape the structure rules simply by deleting its notebook.
+_APP_EVIDENCE = ("package.json", "*.py", "*.ts", "*.tsx", "*.js", "*.jsx")
+
+
+def is_app_example(path: Path) -> bool:
+    """Return True for an example that is an application rather than a notebook.
+
+    Requires positive evidence — application source somewhere in the tree — so
+    that an incomplete recipe is still held to the recipe standard instead of
+    being silently reclassified as an app.
+    """
+    if not path.is_dir() or is_notebook_recipe(path):
         return False
-    if " " in path.name:
-        return False
-    if not (path / ".env.example").exists():
-        return False
-    return any(path.glob("*.ipynb"))
+    return any(
+        p.is_file() and "__pycache__" not in p.parts
+        for pattern in _APP_EVIDENCE
+        for p in path.rglob(pattern)
+    )
 
 
 def example_dir_for_file(file_path: Path) -> Path | None:

--- a/scripts/validate_recipe.py
+++ b/scripts/validate_recipe.py
@@ -30,6 +30,10 @@ from typing import NamedTuple
 
 from packaging.version import Version
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from sarvam_checks import is_app_example  # noqa: E402
+
 # ---------------------------------------------------------------------------
 # Data types
 # ---------------------------------------------------------------------------
@@ -168,7 +172,7 @@ def check_required_files(recipe_dir: Path) -> list[Issue]:
         recipe_dir / "sample_data" / ".gitkeep",
         recipe_dir / "outputs" / ".gitkeep",
     ]
-    return [
+    issues = [
         Issue(
             "error",
             "required-files",
@@ -177,6 +181,46 @@ def check_required_files(recipe_dir: Path) -> list[Issue]:
         )
         for p in required
         if not p.exists()
+    ]
+
+    # A directory whose notebook is simply named differently has a notebook;
+    # reporting it as missing sends the contributor looking for the wrong thing.
+    if not (recipe_dir / nb_name).exists() and any(recipe_dir.glob("*.ipynb")):
+        found = sorted(p.name for p in recipe_dir.glob("*.ipynb"))
+        issues = [i for i in issues if not i.message.endswith(nb_name)]
+        issues.append(Issue(
+            "warning",
+            "required-files",
+            f"Notebook name does not match the directory: expected {nb_name}, found {', '.join(found)}",
+            f"Rename the notebook to {nb_name} so links and tooling can find it.",
+        ))
+
+    return issues
+
+
+def check_app_example_files(recipe_dir: Path) -> list[Issue]:
+    """Check the minimum documentation an app-style example should carry.
+
+    App-style examples are exempt from the notebook-recipe file list, but a
+    reader still needs to know what the example does and which environment
+    variables it wants. Reported as warnings: these directories predate the
+    check, and an incomplete README should not block an unrelated fix.
+
+    Args:
+        recipe_dir: Path to the example directory being checked.
+
+    Returns:
+        One warning Issue per missing file.
+    """
+    return [
+        Issue(
+            "warning",
+            "app-example-files",
+            f"Missing recommended file: {name}",
+            "Add it so the example documents what it does and what it needs.",
+        )
+        for name in ("README.md", ".env.example")
+        if not (recipe_dir / name).exists()
     ]
 
 
@@ -489,18 +533,26 @@ def check_emoji(recipe_dir: Path) -> list[Issue]:
 
 
 def validate_recipe(recipe_dir: Path) -> list[Issue]:
-    """Run all checks on a recipe directory and return aggregated issues.
+    """Run the applicable checks on an example directory.
 
-    Runs check functions in the order defined in CONTRIBUTING.md:
-    required-files → gitignore → requirements → secrets →
-    notebook-structure → no-emoji.
+    Secret scanning applies to every example without exception. The
+    notebook-recipe structure rules from CONTRIBUTING.md apply only where they
+    are meaningful: an app-style example (Next.js, Flask, Streamlit) has no
+    notebook and no sample_data/outputs directories, so requiring them would
+    report false positives rather than real problems.
+
+    Check order follows CONTRIBUTING.md: required-files → gitignore →
+    requirements → secrets → notebook-structure → no-emoji.
 
     Args:
-        recipe_dir: Absolute or relative path to the recipe directory.
+        recipe_dir: Absolute or relative path to the example directory.
 
     Returns:
-        Combined list of Issues from all check functions.
+        Combined list of Issues from the checks that apply.
     """
+    if is_app_example(recipe_dir):
+        return check_app_example_files(recipe_dir) + check_secrets(recipe_dir)
+
     return (
         check_required_files(recipe_dir)
         + check_gitignore(recipe_dir)

--- a/tests/test_validate_pr.py
+++ b/tests/test_validate_pr.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from sarvam_checks import (  # noqa: E402
-    is_recipe_directory,
+    is_app_example,
+    is_example_directory,
+    is_notebook_recipe,
     notebook_cell_sources,
     scan_text_for_secrets,
 )
@@ -32,25 +36,96 @@ class TestSecretScanning:
         assert any(i.check == "secrets" for i in issues)
 
 
-class TestRecipeDetection:
+class TestExampleDetection:
+    """is_example_directory decides *whether* a directory is checked.
+
+    It must depend on membership alone. Anything it inspects inside the
+    directory becomes a condition that the checks for that same thing can
+    never report on.
+    """
+
     def test_recipe_with_env_example_and_notebook(self, tmp_path: Path) -> None:
         recipe = tmp_path / "examples" / "my-recipe"
         recipe.mkdir(parents=True)
         (recipe / ".env.example").write_text("SARVAM_API_KEY=your-sarvam-api-key\n")
         (recipe / "my_recipe.ipynb").write_text('{"cells": [], "nbformat": 4, "nbformat_minor": 5}\n')
-        assert is_recipe_directory(recipe) is True
+        assert is_example_directory(recipe) is True
+        assert is_notebook_recipe(recipe) is True
 
-    def test_app_with_env_example_only(self, tmp_path: Path) -> None:
+    def test_app_style_example_is_still_checked(self, tmp_path: Path) -> None:
+        # No notebook, so the recipe structure rules do not apply — but the
+        # directory is still in scope, so its files are still scanned for keys.
         app_dir = tmp_path / "examples" / "my-streamlit-app"
         app_dir.mkdir(parents=True)
         (app_dir / ".env.example").write_text("SARVAM_API_KEY=your-sarvam-api-key\n")
         (app_dir / "app.py").write_text("import streamlit as st\n")
-        assert is_recipe_directory(app_dir) is False
+        assert is_example_directory(app_dir) is True
+        assert is_notebook_recipe(app_dir) is False
 
-    def test_legacy_example_with_spaces(self, tmp_path: Path) -> None:
-        legacy = tmp_path / "examples" / "Indic Soundbox AI"
-        legacy.mkdir(parents=True)
-        assert is_recipe_directory(legacy) is False
+    def test_recipe_without_env_example_is_still_checked(self, tmp_path: Path) -> None:
+        # .env.example is itself a required file. Gating on it meant a recipe
+        # missing one was never examined, so the error could never be raised.
+        recipe = tmp_path / "examples" / "my-recipe"
+        recipe.mkdir(parents=True)
+        (recipe / "my_recipe.ipynb").write_text('{"cells": [], "nbformat": 4, "nbformat_minor": 5}\n')
+        assert is_example_directory(recipe) is True
+        assert is_notebook_recipe(recipe) is True
+
+    def test_directory_name_with_spaces_is_not_exempt(self, tmp_path: Path) -> None:
+        # A name containing spaces is a naming problem, not a reason to skip
+        # every check including the secret scan.
+        spaced = tmp_path / "examples" / "Indic Soundbox AI"
+        spaced.mkdir(parents=True)
+        assert is_example_directory(spaced) is True
+
+    def test_template_is_excluded(self, tmp_path: Path) -> None:
+        template = tmp_path / "examples" / "TEMPLATE"
+        template.mkdir(parents=True)
+        assert is_example_directory(template) is False
+
+    def test_non_example_directory_excluded(self, tmp_path: Path) -> None:
+        other = tmp_path / "getting-started" / "stt"
+        other.mkdir(parents=True)
+        assert is_example_directory(other) is False
+
+    def test_recipe_cannot_escape_by_deleting_its_notebook(self, tmp_path: Path) -> None:
+        # App classification needs positive evidence. Without it, removing the
+        # notebook would reclassify a recipe as an app and silently drop the
+        # structure rules — the same escape hatch, one level down.
+        recipe = tmp_path / "examples" / "my-recipe"
+        (recipe / "sample_data").mkdir(parents=True)
+        (recipe / "requirements.txt").write_text("sarvamai>=0.1.24\n")
+        assert is_notebook_recipe(recipe) is False
+        assert is_app_example(recipe) is False
+
+    def test_app_example_identified_by_source_files(self, tmp_path: Path) -> None:
+        app_dir = tmp_path / "examples" / "my-app"
+        app_dir.mkdir(parents=True)
+        (app_dir / "app.py").write_text("import streamlit as st\n")
+        assert is_app_example(app_dir) is True
+
+    def test_pycache_alone_is_not_app_evidence(self, tmp_path: Path) -> None:
+        stale = tmp_path / "examples" / "my-recipe"
+        (stale / "__pycache__").mkdir(parents=True)
+        (stale / "__pycache__" / "old.py").write_text("# stale build artefact\n")
+        assert is_app_example(stale) is False
+
+
+class TestExampleCoverage:
+    """Guards the coverage this predicate is responsible for.
+
+    The gate previously inspected directory contents, which silently reduced
+    coverage to 2 of 19 example directories. Asserting the set rather than a
+    count keeps this valid as examples are added.
+    """
+
+    def test_every_example_directory_is_in_scope(self) -> None:
+        examples = Path(__file__).parent.parent / "examples"
+        if not examples.is_dir():
+            pytest.skip("examples/ not present")
+        all_dirs = {d.name for d in examples.iterdir() if d.is_dir()}
+        in_scope = {d.name for d in examples.iterdir() if is_example_directory(d)}
+        assert in_scope == all_dirs - {"TEMPLATE"}
 
 
 class TestNotebookCellSources:


### PR DESCRIPTION
Fixes #128.

## The bug

`is_recipe_directory()` decided *whether* a directory was checked by inspecting what was inside it. Measured against the tree, that admitted **2 of 19** example directories — CI reported PASS on the other 17 without looking at them.

The gate was circular. `.env.example` is itself on the required-files list the validator enforces, so a recipe missing one failed the entry condition, was never handed to `validate_recipe()`, and its missing-`.env.example` error could never fire. The precondition for being checked was one of the things being checked.

The `" " in path.name` clause had the same shape: `examples/Indic Soundbox AI` was exempt from **all** validation — including the secret scan — because of the very naming problem a naming check would have reported.

## The fix

Split the two decisions the one predicate was conflating:

| Predicate | Answers |
|---|---|
| `is_example_directory` | membership only — *which directories are in scope* |
| `is_notebook_recipe` | ships a notebook — *which checks apply* |
| `is_app_example` | has application source — *which checks apply* |

Secret scanning now runs on all 18 in-scope directories. The notebook-recipe structure rules run where they are meaningful; app-style examples get a lighter documentation check as warnings, because requiring `sample_data/` and `outputs/` of a Next.js app reports false positives rather than real problems.

**`is_app_example` requires positive evidence** — application source in the tree — rather than merely the absence of a notebook. Inferring it from absence would reintroduce the same escape hatch one level down: deleting a notebook would reclassify a recipe as an app and silently drop the structure rules. Two tests pin this.

Also: `check_required_files` no longer reports a notebook as missing when the directory has one under a different name. `examples/stt` holds `Song_Lyrics_Generator.ipynb`, and "Missing required file: stt.ipynb" sent contributors looking for the wrong thing. That is now a naming warning that names the file actually present.

## Coverage, before and after

```
before:  2 of 19   govt_scheme_summarizer, Realtime_Speech_Captioning
after:  18 of 19   everything except TEMPLATE
```

Demonstrating the gap that mattered — a planted key in `examples/Travel_Planner`:

```
in scope now : True
secrets found: ['Possible hardcoded API key in: leak_probe.py']
in scope BEFORE this change: False -> file would never have been scanned
```

`TestExampleCoverage` asserts the in-scope set equals every example directory bar `TEMPLATE`, so a future predicate change cannot quietly shrink coverage again. Asserting the set rather than a count keeps it valid as examples are added.

## What this surfaces — please read before merging

Widening coverage exposes pre-existing violations. **This PR touches no `examples/` content**, so CI on the PR itself is green (`ci_validate --base-ref upstream/main` → 0 errors, 0 warnings), and because validation is diff-scoped these only appear when someone edits the directory concerned.

**24 errors across 4 directories** — `examples/stt`, `examples/tts`, `examples/stt-translate`, `examples/converting_wav_into_mp3`. Bare notebook drops missing README, requirements.txt, .env.example, .gitignore, and the two `.gitkeep` placeholders. Genuine CONTRIBUTING violations, 6 each.

**14 warnings**, mostly app-style examples with no `.env.example`, plus 4 notebook-naming warnings.

Zero new `secrets`, `notebook-structure` or `no-emoji` errors — the existing content is clean on those.

I deliberately did **not** fix those 4 directories here: adding scaffolding is a content change, and mixing it into a validator fix makes both harder to review. `python scripts/validate_recipe.py examples/stt --fix` generates most of it if you would prefer that as a follow-up. If you would rather these were warnings until the directories are cleaned up, say so and I will downgrade the severity.

## Also not included

- **`examples/Indic Soundbox AI` is not renamed.** The space no longer grants immunity from checks, which was the actual bug. Renaming the directory would break any external links to it and is better as its own change.
- **`check_requirements` treats `==` as an unpinned dependency.** `Flask==2.3.3` is reported as "missing >= pin" although an exact pin is stricter, and `sarvamai==0.1.30` slips past the minimum-version check for the same reason. This PR does not route the requirements check to any directory that would newly hit it, so nothing regresses, but it is a real bug and I am happy to file it separately.

## Verification

```
$ python -m pytest tests/ -q
89 passed

$ python scripts/ci_validate.py --base-ref upstream/main
PASS — 0 error(s), 0 warning(s)

$ python scripts/sync_sarvam_rules.py --check
sarvam_api_rules.json is up to date.
```
