### PR TITLE
fix(rules): stop the weekly sync workflow opening a timestamp-only PR

### DIFF
--- a/.github/workflows/sync-sarvam-rules.yml
+++ b/.github/workflows/sync-sarvam-rules.yml
@@ -1,7 +1,9 @@
 name: Sync Sarvam API Rules
 
-# Weekly refresh of scripts/sarvam_api_rules.json from docs.sarvam.ai.
-# Opens a PR when the reference file changes.
+# Weekly regeneration of scripts/sarvam_api_rules.json from the canonical
+# lists held in scripts/sync_sarvam_rules.py. Opens a PR only when the rules
+# themselves differ — the script leaves the file untouched otherwise, so a
+# quiet week produces no run output and no pull request.
 
 on:
   schedule:
@@ -41,7 +43,9 @@ jobs:
           commit-message: "chore(rules): sync Sarvam API rules reference from docs"
           title: "chore(rules): sync Sarvam API rules reference from docs"
           body: |
-            Automated weekly sync of `scripts/sarvam_api_rules.json` from [docs.sarvam.ai](https://docs.sarvam.ai).
+            Automated weekly regeneration of `scripts/sarvam_api_rules.json` from the canonical lists in `scripts/sync_sarvam_rules.py`.
+
+            The lists are maintained by hand in that script — nothing is fetched from [docs.sarvam.ai](https://docs.sarvam.ai) beyond a reachability check. This PR therefore only appears when someone has edited those lists; a week with no edit produces no PR.
 
             This file is a contributor reference for current models and language codes. CI does not block PRs on model names yet.
 

--- a/scripts/sync_sarvam_rules.py
+++ b/scripts/sync_sarvam_rules.py
@@ -119,8 +119,15 @@ def sync_rules(*, verbose: bool = False) -> tuple[dict, bool]:
     new_fp = rules_fingerprint(rules)
     changed = True
     if RULES_PATH.exists():
-        existing = json.loads(RULES_PATH.read_text(encoding="utf-8"))
-        changed = rules_fingerprint(existing) != new_fp
+        try:
+            existing = json.loads(RULES_PATH.read_text(encoding="utf-8"))
+            changed = rules_fingerprint(existing) != new_fp
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
+            # An unreadable file needs rewriting, which is what changed=True
+            # means. Raising here would instead crash the one code path able to
+            # repair it, now that the write is gated on this flag.
+            if verbose:
+                print(f"{RULES_PATH} is unreadable ({exc}); treating as out of date.")
 
     return rules, changed
 
@@ -148,11 +155,16 @@ def main() -> int:
         print("sarvam_api_rules.json is up to date.")
         return 0
 
-    RULES_PATH.write_text(render_rules(rules), encoding="utf-8")
-    if args.verbose or changed:
-        print(f"Wrote {RULES_PATH} (changed={changed})")
-    else:
+    # Only write when the rules themselves differ. render_rules() stamps a
+    # fresh synced_at on every call, so writing unconditionally left the working
+    # tree dirty on every run and made the weekly workflow open a pull request
+    # containing nothing but a new timestamp.
+    if not changed:
         print(f"{RULES_PATH} already current.")
+        return 0
+
+    RULES_PATH.write_text(render_rules(rules), encoding="utf-8")
+    print(f"Wrote {RULES_PATH}")
     return 0
 
 

--- a/tests/test_sarvam_rules.py
+++ b/tests/test_sarvam_rules.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -15,7 +16,27 @@ from sarvam_rules import (  # noqa: E402
     get_rules,
     load_rules,
 )
-from sync_sarvam_rules import canonical_rules, rules_fingerprint, sync_rules  # noqa: E402
+from sync_sarvam_rules import (  # noqa: E402
+    canonical_rules,
+    main as sync_main,
+    rules_fingerprint,
+    sync_rules,
+)
+
+
+class _AdvancingClock:
+    """Stands in for the datetime module, one second later on each call.
+
+    Makes a rewrite observable: without it, two runs inside the same second
+    render byte-identical output and a rewrite looks like a skipped write.
+    """
+
+    def __init__(self) -> None:
+        self._seconds = 0
+
+    def now(self, tz: timezone | None = None) -> datetime:
+        self._seconds += 1
+        return datetime(2026, 1, 1, 0, 0, self._seconds, tzinfo=tz or timezone.utc)
 
 
 class TestRulesFile:
@@ -121,3 +142,56 @@ class TestAllowlistValidation:
         path.write_text(json.dumps(stale, indent=2) + "\n")
         _, needs_sync = sync_rules()
         assert needs_sync is True
+
+    def test_write_is_skipped_when_rules_are_unchanged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # render_rules() stamps a fresh synced_at every call, so writing
+        # unconditionally dirtied the tree on every run and made the weekly
+        # workflow open a pull request containing only a new timestamp.
+        #
+        # The clock is advanced between runs deliberately. synced_at has
+        # one-second resolution, so two real back-to-back runs can produce the
+        # same timestamp by chance and the assertion would hold even against
+        # the unfixed code.
+        path = tmp_path / "sarvam_api_rules.json"
+        monkeypatch.setattr("sync_sarvam_rules.RULES_PATH", path)
+        monkeypatch.setattr(sys, "argv", ["sync_sarvam_rules.py"])
+        monkeypatch.setattr("sync_sarvam_rules.datetime", _AdvancingClock())
+
+        assert sync_main() == 0
+        first = path.read_bytes()
+
+        assert sync_main() == 0
+        assert path.read_bytes() == first, (
+            "second run rewrote the file with only a new synced_at, which is "
+            "what makes the weekly workflow open an empty pull request"
+        )
+
+    def test_write_happens_when_rules_actually_change(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / "sarvam_api_rules.json"
+        monkeypatch.setattr("sync_sarvam_rules.RULES_PATH", path)
+        monkeypatch.setattr(sys, "argv", ["sync_sarvam_rules.py"])
+
+        stale = canonical_rules()
+        stale["models"]["chat"]["allowed"] = ["sarvam-obsolete"]
+        path.write_text(json.dumps(stale, indent=2) + "\n", encoding="utf-8")
+
+        assert sync_main() == 0
+        written = json.loads(path.read_text(encoding="utf-8"))
+        assert written["models"]["chat"]["allowed"] == canonical_rules()["models"]["chat"]["allowed"]
+
+    def test_unreadable_rules_file_is_rewritten_not_raised(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Gating the write on `changed` makes this the only path that can
+        # repair the file, so it must not crash on malformed JSON.
+        path = tmp_path / "sarvam_api_rules.json"
+        path.write_text("{ not valid json", encoding="utf-8")
+        monkeypatch.setattr("sync_sarvam_rules.RULES_PATH", path)
+        monkeypatch.setattr(sys, "argv", ["sync_sarvam_rules.py"])
+
+        assert sync_main() == 0
+        assert json.loads(path.read_text(encoding="utf-8"))["schema_version"] == 1


### PR DESCRIPTION
Fixes #129.

## The bug

`main()` wrote `sarvam_api_rules.json` unconditionally, and `render_rules()` stamps a fresh `synced_at` on every call. The working tree was therefore dirty after every run, so the Monday workflow handed `peter-evans/create-pull-request` a diff and opened a PR carrying no information:

```diff
-  "synced_at": "2026-08-06T07:55:33Z",
+  "synced_at": "2026-08-19T04:22:44Z",
```

One line, every week, forever. That costs a review every Monday and trains reviewers to skim — which matters precisely on the week the bot *does* carry a real model change.

## The fix

The detection this needs already existed and simply never gated the write. `sync_rules()` returns a `changed` flag computed by `rules_fingerprint()`, which deliberately excludes `synced_at`. Return early when it is `False`:

```python
if not changed:
    print(f"{RULES_PATH} already current.")
    return 0
```

A useful side effect: `synced_at` now records when the rules last actually changed rather than when the job last ran, which is the more informative reading of the field.

## Guarding the repair path

Gating the write on `changed` makes `sync_rules()` the only code path that can rewrite the file, so the fingerprint comparison must not raise on a malformed one. Previously `json.loads` would throw straight out of the function; now an unreadable file is treated as out of date and gets rewritten, which is the outcome `changed=True` already means. Without this, a corrupted rules file would leave the workflow failing every week with no way to self-repair.

## Documentation corrected

The workflow header and generated PR body both claimed a sync *from docs.sarvam.ai*. The canonical model and language lists are hand-maintained in `scripts/sync_sarvam_rules.py`; nothing is fetched beyond `verify_docs_reachable()`, whose result is printed and discarded. Both now say what actually happens, so the next reader does not assume the file auto-updates itself from the docs site.

## Verification

Four paths exercised directly, three of them pinned by new tests:

| Situation | Behaviour |
|---|---|
| file missing | written |
| rules unchanged | **not written** — byte-identical, tree stays clean |
| rules genuinely differ | written, canonical values restored |
| file corrupt | repaired rather than raising |

```
$ python scripts/sync_sarvam_rules.py --verbose
docs.sarvam.ai: reachable at https://docs.sarvam.ai
scripts/sarvam_api_rules.json already current.

$ python scripts/sync_sarvam_rules.py
scripts/sarvam_api_rules.json already current.

$ git status --short scripts/sarvam_api_rules.json
                     # clean — no PR would be opened

$ python -m pytest tests/ -q
85 passed
```

One note on the tests. `test_write_is_skipped_when_rules_are_unchanged` needs `_AdvancingClock`, because `synced_at` has one-second resolution: two real back-to-back runs frequently render byte-identical output, so without a controlled clock the assertion passes against the unfixed code too. I confirmed the fixed tests fail on `main`:

```
FAILED test_write_is_skipped_when_rules_are_unchanged
        - second run rewrote the file with only a new synced_at
FAILED test_unreadable_rules_file_is_rewritten_not_raised
        - json.decoder.JSONDecodeError
```

## Left alone

`verify_docs_reachable()` still has no effect on the exit status — its result is printed under `--verbose` and otherwise ignored. Deciding whether an unreachable docs site should fail the job, warn, or stay advisory is a product call rather than a bug fix, so I have not changed it here.
