### PR TITLE
fix(ci): define missing DEPRECATED_API_RULES in sarvam_checks.py

### DIFF
--- a/scripts/sarvam_checks.py
+++ b/scripts/sarvam_checks.py
@@ -42,6 +42,19 @@ SECRET_ASSIGNMENT_RE = re.compile(
 
 SARVAM_KEY_PREFIX_RE = re.compile(r"\bsk_[a-zA-Z0-9]{16,}\b")
 
+DEPRECATED_API_RULES = [
+    (
+        re.compile(r"api\.sarvam\.ai/v1/translate"),
+        "The /v1/translate endpoint is deprecated. Use Mayura (v1) instead.",
+        "deprecated-api",
+    ),
+    (
+        re.compile(r"api\.sarvam\.ai/v1/speech-to-text-translate"),
+        "The /v1/speech-to-text-translate endpoint is deprecated. Use Saaras (v3) + Mayura (v1).",
+        "deprecated-api",
+    ),
+]
+
 PLACEHOLDER_KEY_PATTERNS = (
     "your-sarvam-api-key",
     "your_sarvam_api_key",


### PR DESCRIPTION
## Summary
This PR fixes a `NameError` in `scripts/sarvam_checks.py` where `DEPRECATED_API_RULES` was referenced in `scan_added_lines_for_deprecated_api` but not defined in the module.

I have added the missing definition for `DEPRECATED_API_RULES` with relevant regex patterns for deprecated Sarvam AI endpoints.

## Security checklist (required)
- [x] No real API keys in code, notebooks, configs, comments, or PR description
- [x] `SARVAM_API_KEY` is loaded from the environment — not hardcoded
- [x] `.env` is gitignored (new recipes must include `.env.example`)

## Changes
- Defined `DEPRECATED_API_RULES` in `scripts/sarvam_checks.py`.
- Verified the fix with a reproduction script.
- Confirmed that all existing tests pass.