### PR TITLE
fix(ci): close four gaps in the secret scanner

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - "examples/**"
       - "getting-started/**"
+      - "integrations/**"
       - "scripts/**"
       - "tests/**"
       - "requirements-dev.txt"

--- a/scripts/sarvam_checks.py
+++ b/scripts/sarvam_checks.py
@@ -70,6 +70,13 @@ BINARY_SUFFIXES: frozenset[str] = frozenset(
 
 SCAN_SKIP_NAMES = frozenset({".gitkeep", "package-lock.json"})
 
+# Committable templates. Every other .env* name holds real values.
+ENV_TEMPLATE_NAMES = frozenset({".env.example", ".env.sample", ".env.template"})
+
+# Notebook output mime types that hold text a key can hide in. Anything else
+# (image/png, application/pdf) is base64 and would only produce false positives.
+TEXTUAL_OUTPUT_MIME_PREFIXES = ("text/", "application/json")
+
 LEGACY_EXAMPLE_DIRS = frozenset({"TEMPLATE"})
 
 
@@ -105,13 +112,25 @@ def example_dir_for_file(file_path: Path) -> Path | None:
     return None
 
 
+def is_committed_env_file(path: Path) -> bool:
+    """Return True for a real .env file, including .env.local / .env.production.
+
+    Template files (.env.example and friends) are meant to be committed, and
+    .envrc belongs to direnv rather than being an env file at all.
+    """
+    name = path.name
+    if name in ENV_TEMPLATE_NAMES:
+        return False
+    return name == ".env" or name.startswith(".env.")
+
+
 def should_scan_file(path: Path) -> bool:
     """Return True when a file should be scanned for secrets and API usage."""
     if not path.is_file():
         return False
     if path.name in SCAN_SKIP_NAMES:
         return False
-    if path.name == ".env":
+    if path.name.startswith(".env"):
         return True
     if path.suffix.lower() in BINARY_SUFFIXES:
         return False
@@ -129,6 +148,8 @@ def should_scan_file(path: Path) -> bool:
         ".toml",
         ".env.example",
         ".sh",
+        ".html",
+        ".htm",
     } or path.name in {".env.example", "Dockerfile"}
 
 
@@ -205,6 +226,42 @@ def notebook_cell_sources(nb_path: Path) -> list[str]:
     return sources
 
 
+def _joined_text(value: object) -> str:
+    """Flatten a notebook text field, which may be a list of lines or a string."""
+    if isinstance(value, list):
+        return "".join(str(part) for part in value)
+    return str(value) if value else ""
+
+
+def notebook_cell_outputs(nb_path: Path) -> list[str]:
+    """Return each cell's saved output text.
+
+    Executed notebooks are committed with their outputs intact, so a printed
+    key or an auth traceback lands on disk just like source code does.
+    """
+    try:
+        nb = json.loads(nb_path.read_text(encoding="utf-8-sig"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return []
+
+    per_cell: list[str] = []
+    for cell in nb.get("cells", []):
+        parts: list[str] = []
+        for output in cell.get("outputs") or []:
+            if not isinstance(output, dict):
+                continue
+            parts.append(_joined_text(output.get("text")))
+            parts.append(_joined_text(output.get("evalue")))
+            parts.append(_joined_text(output.get("traceback")))
+            data = output.get("data")
+            if isinstance(data, dict):
+                for mime, payload in data.items():
+                    if str(mime).startswith(TEXTUAL_OUTPUT_MIME_PREFIXES):
+                        parts.append(_joined_text(payload))
+        per_cell.append("".join(part for part in parts if part))
+    return per_cell
+
+
 # ---------------------------------------------------------------------------
 # Check functions
 # ---------------------------------------------------------------------------
@@ -256,13 +313,13 @@ def scan_file_for_secrets(file_path: Path, repo_root: Path | None = None) -> lis
         else str(file_path)
     )
 
-    if file_path.name == ".env":
+    if is_committed_env_file(file_path):
         return [
             Issue(
                 "error",
                 "secrets",
-                f"Committed .env file: {rel}",
-                "Never commit .env. Add .env to .gitignore and provide .env.example instead.",
+                f"Committed {file_path.name} file: {rel}",
+                "Never commit a .env file. Add it to .gitignore and provide .env.example instead.",
             )
         ]
 
@@ -276,6 +333,8 @@ def scan_file_for_secrets(file_path: Path, repo_root: Path | None = None) -> lis
         for idx, cell_src in enumerate(notebook_cell_sources(file_path)):
             for issue in scan_text_for_secrets(cell_src, f"{rel} (cell {idx})"):
                 issues.append(issue)
+        for idx, cell_out in enumerate(notebook_cell_outputs(file_path)):
+            issues.extend(scan_text_for_secrets(cell_out, f"{rel} (cell {idx} output)"))
         return issues
 
     return scan_text_for_secrets(text, rel)

--- a/scripts/validate_pr.py
+++ b/scripts/validate_pr.py
@@ -5,7 +5,7 @@ Usage:
     python scripts/validate_pr.py --base-ref main --strict
     python scripts/validate_pr.py --base-ref main --json
 
-Runs on changed files under examples/ and getting-started/:
+Runs on changed files under examples/, getting-started/ and integrations/:
   - Secret / API key leak detection (blocking)
   - Client-side API key references (blocking)
 
@@ -29,14 +29,19 @@ from sarvam_checks import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-SCAN_PREFIXES = ("examples/", "getting-started/")
+SCAN_PREFIXES = ("examples/", "getting-started/", "integrations/")
+
+
+def is_scanned_path(rel_path: str) -> bool:
+    """Return True when a repo-relative path falls inside secret-scan scope."""
+    return rel_path.startswith(SCAN_PREFIXES)
 
 
 def changed_paths(base_ref: str, head_ref: str = "HEAD") -> list[Path]:
     """Return repo-relative paths changed in the PR."""
     paths: list[Path] = []
     for rel in git_diff_name_only(base_ref, head_ref):
-        if rel.startswith(SCAN_PREFIXES):
+        if is_scanned_path(rel):
             paths.append(Path(rel))
     return paths
 

--- a/tests/test_validate_pr.py
+++ b/tests/test_validate_pr.py
@@ -1,15 +1,19 @@
 """Unit tests for scripts/sarvam_checks.py and scripts/validate_pr.py."""
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
+import validate_pr  # noqa: E402
 from sarvam_checks import (  # noqa: E402
     is_recipe_directory,
     notebook_cell_sources,
+    scan_file_for_secrets,
     scan_text_for_secrets,
+    should_scan_file,
 )
 
 
@@ -63,3 +67,113 @@ class TestNotebookCellSources:
         nb_path.write_bytes(b"\xef\xbb\xbf" + content.encode("utf-8"))
         sources = notebook_cell_sources(nb_path)
         assert sources == ['model = "sarvam-m"']
+
+
+class TestScanScope:
+    """Which repo paths get scanned for leaked keys at all."""
+
+    def test_integrations_paths_are_scanned(self) -> None:
+        # integrations/ ships seven notebooks that call the Sarvam API during
+        # authoring; they must not bypass the secret scan.
+        assert validate_pr.is_scanned_path("integrations/build_voice_agent_with_twilio.ipynb") is True
+
+    def test_examples_and_getting_started_stay_scanned(self) -> None:
+        assert validate_pr.is_scanned_path("examples/tts/app.py") is True
+        assert validate_pr.is_scanned_path("getting-started/stt/STT_API_Tutorial.ipynb") is True
+
+    def test_unrelated_paths_are_not_scanned(self) -> None:
+        assert validate_pr.is_scanned_path("README.md") is False
+        assert validate_pr.is_scanned_path("scripts/sarvam_checks.py") is False
+
+
+class TestScannableFileTypes:
+    def test_html_templates_are_scanned(self, tmp_path: Path) -> None:
+        # Four example apps ship Flask templates; an inline <script> can carry a key.
+        page = tmp_path / "index.html"
+        page.write_text("<script>const KEY = 'x';</script>", encoding="utf-8")
+        assert should_scan_file(page) is True
+
+
+class TestCommittedEnvFiles:
+    def test_env_local_is_flagged_as_committed_env(self, tmp_path: Path) -> None:
+        env_file = tmp_path / ".env.local"
+        env_file.write_text("SARVAM_API_KEY=sarvam_fake_key_abcdefghijklmnopqrst\n", encoding="utf-8")
+        assert any(i.check == "secrets" for i in scan_file_for_secrets(env_file))
+
+    def test_env_production_is_flagged_as_committed_env(self, tmp_path: Path) -> None:
+        env_file = tmp_path / ".env.production"
+        env_file.write_text("SARVAM_API_KEY=sarvam_fake_key_abcdefghijklmnopqrst\n", encoding="utf-8")
+        assert any(i.check == "secrets" for i in scan_file_for_secrets(env_file))
+
+    def test_env_example_is_not_flagged(self, tmp_path: Path) -> None:
+        env_file = tmp_path / ".env.example"
+        env_file.write_text("SARVAM_API_KEY=your-sarvam-api-key\n", encoding="utf-8")
+        assert scan_file_for_secrets(env_file) == []
+
+    def test_envrc_is_not_flagged_as_committed_env(self, tmp_path: Path) -> None:
+        # direnv's .envrc is routinely committed and is not a .env file.
+        envrc = tmp_path / ".envrc"
+        envrc.write_text("export SARVAM_API_KEY=$(pass sarvam/key)\n", encoding="utf-8")
+        assert scan_file_for_secrets(envrc) == []
+
+
+class TestNotebookOutputScanning:
+    """Saved cell outputs leak keys as readily as cell source does."""
+
+    @staticmethod
+    def _notebook(outputs: list[dict]) -> str:
+        return json.dumps(
+            {
+                "cells": [
+                    {"cell_type": "code", "source": ["print(resolve_key())"], "outputs": outputs}
+                ],
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        )
+
+    def test_key_in_stream_output_is_flagged(self, tmp_path: Path) -> None:
+        fake_key = "sk_" + ("x" * 24)
+        nb = tmp_path / "stream.ipynb"
+        nb.write_text(
+            self._notebook([{"output_type": "stream", "name": "stdout", "text": [f"{fake_key}\n"]}]),
+            encoding="utf-8",
+        )
+        assert any(i.check == "secrets" for i in scan_file_for_secrets(nb))
+
+    def test_key_in_execute_result_is_flagged(self, tmp_path: Path) -> None:
+        fake_key = "sk_" + ("y" * 24)
+        nb = tmp_path / "result.ipynb"
+        nb.write_text(
+            self._notebook(
+                [{"output_type": "execute_result", "data": {"text/plain": [f"'{fake_key}'"]}, "metadata": {}}]
+            ),
+            encoding="utf-8",
+        )
+        assert any(i.check == "secrets" for i in scan_file_for_secrets(nb))
+
+    def test_key_in_error_traceback_is_flagged(self, tmp_path: Path) -> None:
+        fake_key = "sk_" + ("z" * 24)
+        nb = tmp_path / "error.ipynb"
+        nb.write_text(
+            self._notebook(
+                [
+                    {
+                        "output_type": "error",
+                        "ename": "AuthError",
+                        "evalue": "bad key",
+                        "traceback": [f'  headers={{"api-subscription-key": "{fake_key}"}}'],
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        assert any(i.check == "secrets" for i in scan_file_for_secrets(nb))
+
+    def test_clean_notebook_outputs_produce_no_findings(self, tmp_path: Path) -> None:
+        nb = tmp_path / "clean.ipynb"
+        nb.write_text(
+            self._notebook([{"output_type": "stream", "name": "stdout", "text": ["Transcript ready\n"]}]),
+            encoding="utf-8",
+        )
+        assert scan_file_for_secrets(nb) == []


### PR DESCRIPTION
## What is wrong

The scanner that looks for leaked API keys does not look everywhere. Four places are missed today.

**1. The integrations folder is never scanned.**
`SCAN_PREFIXES` in `scripts/validate_pr.py` lists only `examples/` and `getting-started/`. The seven notebooks in `integrations/` sit outside it. The folder is also missing from the `paths:` trigger in `.github/workflows/pr-check.yml`, so a pull request that only touches those notebooks does not even start the check.

**2. Saved notebook output is never read.**
`scan_file_for_secrets` reads only the source of each cell. Notebooks get committed with their output still inside them, so a key printed by a cell, or one that appears in an error message, lands in the repo and nothing looks at it.

**3. Only a file named exactly `.env` is caught.**
`.env.local` and `.env.production` hold real values just the same, and were being ignored.

**4. HTML is not a file type the scanner opens.**
Four example apps ship Flask templates, and an inline `<script>` block can hold a key.

## What this changes

- Adds `integrations/` to the scan list and to the workflow trigger.
- Reads saved notebook output as well as cell source.
- Treats any `.env` file as a committed env file, while still allowing `.env.example` and direnv's `.envrc`.
- Adds `.html` and `.htm` to the file types that get opened.

Picture output is deliberately left alone. Image data is stored as a long run of letters and numbers that would otherwise look like a key and cause false alarms.

## How it was checked

11 new tests, each one written and watched failing before the fix went in. The full suite is 94 passing.

Checked against the repo as it stands today:

- All seven notebooks in `integrations/` are now in scope.
- The five Flask templates are now opened.
- A key planted in notebook output is caught. Before this change it was invisible.
- Image output produces no finding.
- Scanning all 133 files currently in scope produces no new findings, so this will not start failing anyone's open pull request.

## Note for reviewers

This deliberately leaves `notebook_cell_sources` untouched, because PR #131 rewrites that same function. The two changes should merge in either order without clashing.
