### PR TITLE
fix(ci): stop the secret scanner publishing the key it found

### DIFF
--- a/scripts/sarvam_checks.py
+++ b/scripts/sarvam_checks.py
@@ -226,7 +226,10 @@ def scan_text_for_secrets(text: str, rel_path: str) -> list[Issue]:
             Issue(
                 "error",
                 "secrets",
-                f"Possible hardcoded API key in {rel_path}: {snippet[:60]}",
+                # Never include the matched value. This message is rendered by
+                # scripts/pr_comment.py and posted to the PR, so the key would
+                # end up published in a public comment that outlives the commit.
+                f"Possible hardcoded API key in {rel_path}",
                 "Load SARVAM_API_KEY from the environment (.env + python-dotenv). "
                 "See https://docs.sarvam.ai/api-reference-docs/authentication",
             )

--- a/tests/test_validate_pr.py
+++ b/tests/test_validate_pr.py
@@ -31,6 +31,25 @@ class TestSecretScanning:
         issues = scan_text_for_secrets(text, "app.py")
         assert any(i.check == "secrets" for i in issues)
 
+    def test_finding_never_repeats_the_key_value(self) -> None:
+        # The finding is rendered by scripts/pr_comment.py and posted to the PR
+        # with `gh pr comment`, so anything in the message becomes public. A
+        # contributor can force-push the commit away; the comment stays.
+        fake_key = "sk_" + ("z" * 24)
+        text = f'SARVAM_API_KEY = "{fake_key}"'
+        issues = scan_text_for_secrets(text, "app.py")
+
+        assert issues, "expected the hardcoded key to be flagged"
+        for issue in issues:
+            assert fake_key not in issue.message
+            assert fake_key not in (issue.suggestion or "")
+
+    def test_finding_still_names_the_file(self) -> None:
+        # Removing the value must not remove the contributor's ability to find it.
+        fake_key = "sk_" + ("y" * 24)
+        issues = scan_text_for_secrets(f'SARVAM_API_KEY = "{fake_key}"', "src/app.py")
+        assert any("src/app.py" in i.message for i in issues)
+
 
 class TestRecipeDetection:
     def test_recipe_with_env_example_and_notebook(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## The problem

The tool that stops a key being committed publishes it instead.

`scripts/sarvam_checks.py:229` builds the hardcoded-key finding as:

```python
f"Possible hardcoded API key in {rel_path}: {snippet[:60]}"
```

`snippet` is the whole matched assignment, key included. That message is rendered by `scripts/pr_comment.py:41` and posted to the pull request by `.github/workflows/pr-check.yml`:

```yaml
gh pr comment "${{ github.event.pull_request.number }}" --body-file pr-comment.md
```

So a contributor who accidentally commits a key gets it written into a public comment on a public repository. They can force-push the commit away. The comment stays.

## Reproduction

Running the scanner and `pr_comment.py` together, on a throwaway file containing a fake key, produced this comment body before the change:

```
**1 blocking issue(s):**

### secrets

- Possible hardcoded API key in app.py: SARVAM_API_KEY = "sk_AAAAAAAAAAAAAAAAAAAAAAAA"
```

The `[:60]` slice is not much protection. At realistic key lengths the whole key fits:

| Key shape | Full key published |
|---|---|
| `sk_` + 24 characters | yes |
| `sk_` + 16 characters | yes |
| 18-character generic key | yes |

Only a key long enough to push the message past 60 characters gets clipped, and then most of it still goes out.

## The fix

Drop the value from the message. One line.

The `sk_` branch twelve lines below at line 241 already does exactly this:

```python
f"Possible Sarvam API key (sk_*) in {rel_path}"
```

The same scan can emit both messages for the same file — one safe, one not. This makes them consistent.

Nothing is lost for the contributor. The finding still names the file, the check name is still `secrets`, and the suggestion still explains how to load the key from the environment. `snippet` is still used for the placeholder test, so the match logic is untouched.

## Tests

Two added, both written before the fix and watched failing first:

- `test_finding_never_repeats_the_key_value` — asserts the key appears in neither the message nor the suggestion. Before the fix it failed with the key visible in the assertion output.
- `test_finding_still_names_the_file` — a guard, so removing the value cannot quietly remove the contributor's ability to locate it.

## Checks that were run

```
python3 -m pytest tests/ -q                       84 passed (82 before, 2 added)
python3 scripts/ci_validate.py --base-ref main    PASS, 0 errors
python3 scripts/sync_sarvam_rules.py --check      up to date
```

I also re-ran the end-to-end reproduction afterwards. The rendered comment body is now:

```
- Possible hardcoded API key in app.py
```

## Note on overlapping pull requests

This touches `scan_text_for_secrets`, which no open pull request modifies. #141 and #142 both change `scripts/sarvam_checks.py` but only add the `DEPRECATED_API_RULES` constant near line 42. My own #147 changes `should_scan_file` and `scan_file_for_secrets` and does not touch this message. This should merge in any order alongside them.
