### PR TITLE
fix(examples): write real newlines in the generated subtitle file

### DIFF
--- a/examples/stt-translate/Subtitles.ipynb
+++ b/examples/stt-translate/Subtitles.ipynb
@@ -379,9 +379,9 @@
         "            transcript = result[\"transcript\"]\n",
         "\n",
         "            # Write the SRT entry\n",
-        "            srt_file.write(f\"{i}\\\\n\")\n",
-        "            srt_file.write(f\"{start_timestamp} --> {end_timestamp}\\\\n\")\n",
-        "            srt_file.write(f\"{transcript}\\\\n\\\\n\")\n"
+        "            srt_file.write(f\"{i}\\n\")\n",
+        "            srt_file.write(f\"{start_timestamp} --> {end_timestamp}\\n\")\n",
+        "            srt_file.write(f\"{transcript}\\n\\n\")\n"
       ]
     },
     {


### PR DESCRIPTION
## The bug

`examples/stt-translate/Subtitles.ipynb` writes its SRT file with double-backslash escapes:

```python
srt_file.write(f"{i}\\n")
srt_file.write(f"{start_timestamp} --> {end_timestamp}\\n")
srt_file.write(f"{transcript}\\n\\n")
```

In Python `"\\n"` is a literal backslash followed by the letter n, not a newline. So the recipe's entire output — the subtitle file it exists to produce — comes out as one long line with visible `\n` text in it. No subtitle player can read it.

## Reproduction

Extracting the cell and running it against three dummy entries.

**Before** — 0 real newlines, 12 literal backslash-n sequences:

```
b'1\\n00:00:00,000 --> 00:00:02,500\\nHello world\\n\\n2\\n...'
```

**After** — 12 real newlines, 0 literal sequences, well-formed SRT:

```
1
00:00:00,000 --> 00:00:02,500
Hello world

2
00:00:02,500 --> 00:00:06,125
This is the second subtitle line.
```

## Checks

```
python3 -m pytest tests/ -q                      82 passed
python3 scripts/ci_validate.py --base-ref main   PASS, 0 errors
```

The notebook still parses, keeps nbformat 4.0, has no BOM, and cell 19 is the only cell that differs from main. Its execution_count and outputs are untouched. No open PR touches this notebook.

## Separate pre-existing issue, deliberately left alone

`validate_recipe.py` reports 7 missing-file errors for `examples/stt-translate/` on main today — no README.md, no requirements.txt and so on. That is unrelated scaffolding and belongs in its own change, so this diff stays at the three lines. I confirmed the validator output is byte-identical before and after.