### PR TITLE
fix(ci): make the recipe validator survive its own edge cases

### DIFF
--- a/scripts/validate_recipe.py
+++ b/scripts/validate_recipe.py
@@ -28,7 +28,7 @@ import sys
 from pathlib import Path
 from typing import NamedTuple
 
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -210,6 +210,27 @@ def check_gitignore(recipe_dir: Path) -> list[Issue]:
     ]
 
 
+def _pinned_version(line: str) -> Version | None:
+    """Extract the >= pinned version from a requirements.txt line.
+
+    Args:
+        line: A single stripped requirements.txt line.
+
+    Returns:
+        The pinned Version, or None when the line carries no >= pin or the
+        pinned text is not a valid version (for example 'sarvamai>=0.1.24.').
+        A malformed pin is reported as an Issue by the caller rather than
+        raising InvalidVersion out of the whole validation run.
+    """
+    m = re.search(r">=([\d.]+)", line)
+    if not m:
+        return None
+    try:
+        return Version(m.group(1))
+    except InvalidVersion:
+        return None
+
+
 def check_requirements(recipe_dir: Path) -> list[Issue]:
     """Validate dependency version pins in requirements.txt.
 
@@ -240,7 +261,8 @@ def check_requirements(recipe_dir: Path) -> list[Issue]:
         # Extract package name (handles extras like Pillow[jpeg]).
         pkg_name = re.split(r"[>=<!;\[\s@]", line, maxsplit=1)[0].lower()
 
-        if not re.search(r">=", line):
+        has_pin = bool(re.search(r">=", line))
+        if not has_pin:
             issues.append(Issue(
                 "error", "requirements",
                 f"Package missing >= pin: {line!r}",
@@ -249,8 +271,14 @@ def check_requirements(recipe_dir: Path) -> list[Issue]:
 
         if pkg_name == "sarvamai":
             has_sarvam = True
-            m = re.search(r">=([\d.]+)", line)
-            if m and Version(m.group(1)) < _MIN_SARVAMAI_VERSION:
+            pinned = _pinned_version(line)
+            if has_pin and pinned is None:
+                issues.append(Issue(
+                    "error", "requirements",
+                    f"Unparseable version pin: {line!r}",
+                    f"Use a valid >= version pin (example: sarvamai>={_MIN_SARVAMAI_VERSION}).",
+                ))
+            elif pinned is not None and pinned < _MIN_SARVAMAI_VERSION:
                 issues.append(Issue(
                     "error", "requirements",
                     f"sarvamai must be >={_MIN_SARVAMAI_VERSION}, found: {line!r}",
@@ -258,8 +286,14 @@ def check_requirements(recipe_dir: Path) -> list[Issue]:
                 ))
 
         if pkg_name == "pillow":
-            m = re.search(r">=([\d.]+)", line)
-            if m and Version(m.group(1)) < _MIN_PILLOW_VERSION:
+            pinned = _pinned_version(line)
+            if has_pin and pinned is None:
+                issues.append(Issue(
+                    "error", "requirements",
+                    f"Unparseable version pin: {line!r}",
+                    f"Use a valid >= version pin (example: Pillow>={_MIN_PILLOW_VERSION}).",
+                ))
+            elif pinned is not None and pinned < _MIN_PILLOW_VERSION:
                 issues.append(Issue(
                     "error", "requirements",
                     f"Pillow must be >={_MIN_PILLOW_VERSION} (CVE guard), found: {line!r}",
@@ -534,7 +568,16 @@ def auto_fix(recipe_dir: Path) -> list[str]:
     fixes: list[str] = []
 
     gitignore = recipe_dir / ".gitignore"
-    required_patterns = [".env", "sample_data/*", "outputs/*"]
+    # The negations keep the .gitkeep placeholders created below trackable —
+    # without them sample_data/* and outputs/* ignore the very files this
+    # function just wrote, and the recipe then fails validation for them.
+    required_patterns = [
+        ".env",
+        "sample_data/*",
+        "!sample_data/.gitkeep",
+        "outputs/*",
+        "!outputs/.gitkeep",
+    ]
 
     if not gitignore.exists():
         gitignore.write_text("\n".join(required_patterns) + "\n")

--- a/tests/test_validate_recipe.py
+++ b/tests/test_validate_recipe.py
@@ -13,10 +13,13 @@ Test organisation mirrors the check functions in validate_recipe.py:
     TestNotebookStructure   → check_notebook_structure
     TestEmoji               → check_emoji
     TestValidateRecipe      → validate_recipe (integration)
+    TestAutoFix             → auto_fix
 """
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -28,6 +31,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from validate_recipe import (  # noqa: E402
     Issue,
+    auto_fix,
     check_emoji,
     check_gitignore,
     check_notebook_structure,
@@ -326,6 +330,23 @@ class TestRequirements:
         (d / "requirements.txt").write_text("requests>=2.31.0\n", encoding="utf-8")
         assert not _errors(check_requirements(d))
         assert any("sarvamai" in i.message for i in _warnings(check_requirements(d)))
+
+    def test_malformed_sarvamai_pin_is_reported_not_raised(self, tmp_path: Path) -> None:
+        # '0.1.24.' has a trailing dot and is not a valid version. It must be
+        # reported as an error, never raise out of the checker — an exception
+        # here aborts the whole CI run before results are written.
+        d = _make_recipe(tmp_path)
+        (d / "requirements.txt").write_text("sarvamai>=0.1.24.\n", encoding="utf-8")
+        errors = _errors(check_requirements(d))
+        assert any("0.1.24." in i.message for i in errors)
+
+    def test_malformed_pillow_pin_is_reported_not_raised(self, tmp_path: Path) -> None:
+        d = _make_recipe(tmp_path)
+        (d / "requirements.txt").write_text(
+            "sarvamai>=0.1.24\nPillow>=12.1.\n", encoding="utf-8"
+        )
+        errors = _errors(check_requirements(d))
+        assert any("12.1." in i.message for i in errors)
 
     def test_absent_requirements_returns_empty_list(self, tmp_path: Path) -> None:
         d = _make_recipe(tmp_path)
@@ -661,3 +682,51 @@ class TestValidateRecipe:
         assert "requirements" in checks_found
         assert "notebook-structure" in checks_found
         assert "no-emoji" in checks_found
+
+
+# ---------------------------------------------------------------------------
+# TestAutoFix
+# ---------------------------------------------------------------------------
+
+
+class TestAutoFix:
+    def test_gitignore_negates_the_gitkeep_placeholders(self, tmp_path: Path) -> None:
+        # sample_data/* and outputs/* would otherwise ignore the .gitkeep files
+        # auto_fix creates in the same run, so the negations must be written too.
+        d = tmp_path / "my-recipe"
+        d.mkdir()
+        auto_fix(d)
+        lines = (d / ".gitignore").read_text(encoding="utf-8").splitlines()
+        assert "!sample_data/.gitkeep" in lines
+        assert "!outputs/.gitkeep" in lines
+
+    def test_missing_negations_appended_to_existing_gitignore(self, tmp_path: Path) -> None:
+        d = tmp_path / "my-recipe"
+        d.mkdir()
+        (d / ".gitignore").write_text(
+            ".env\nsample_data/*\noutputs/*\n", encoding="utf-8"
+        )
+        auto_fix(d)
+        lines = (d / ".gitignore").read_text(encoding="utf-8").splitlines()
+        assert "!sample_data/.gitkeep" in lines
+        assert "!outputs/.gitkeep" in lines
+
+    @pytest.mark.skipif(shutil.which("git") is None, reason="git is not installed")
+    def test_git_tracks_the_gitkeep_files_after_auto_fix(self, tmp_path: Path) -> None:
+        # The end-to-end consequence: after auto_fix, a real 'git add -A' must
+        # stage both .gitkeep files, otherwise the recipe fails validation for
+        # the very files auto_fix just created.
+        subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+        d = tmp_path / "my-recipe"
+        d.mkdir()
+        auto_fix(d)
+        subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+        tracked = subprocess.run(
+            ["git", "ls-files"],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.split()
+        assert "my-recipe/sample_data/.gitkeep" in tracked
+        assert "my-recipe/outputs/.gitkeep" in tracked


### PR DESCRIPTION
Two faults in `scripts/validate_recipe.py`, both found by running it rather than reading it. Fixed with tests written first.

## 1. A typo'd version pin killed the whole run

`check_requirements` captures the version with a `>=([\d.]+)` regex, which happily takes a trailing dot, then hands it to `packaging`:

```
requirements.txt containing: sarvamai>=0.1.24.
-> packaging.version.InvalidVersion: Invalid version: '0.1.24.'   (unhandled)
```

That escaped `check_requirements` and killed `ci_validate.py` before it wrote `validation-results.json`, so the workflow's "Post validation summary on failure" step then died too with FileNotFoundError. The contributor saw a red cross, a stack trace, and no comment explaining anything.

A malformed pin is now an ordinary reported error:

```
[ERROR  ] [requirements] Unparseable version pin: 'sarvamai>=0.1.24.'
  Suggestion: Use a valid >= version pin (example: sarvamai>=0.1.24).
FAIL — my-recipe: 2 error(s), 0 warning(s)   EXIT=1
```

Clean exit 1, so the results file is written and the comment step works.

## 2. --fix wrote a .gitignore that ignored the files it had just created

The auto-fix path created `sample_data/.gitkeep` and `outputs/.gitkeep`, then wrote a `.gitignore` containing `sample_data/*` and `outputs/*` with no negations. In a real git repo:

```
after auto_fix + git add -A:
git ls-files -> ['my-recipe/.env.example', 'my-recipe/.gitignore']
```

Both .gitkeep files ignored, so the "repaired" recipe still failed validation for missing files. The generated file now carries `!sample_data/.gitkeep` and `!outputs/.gitkeep`, matching `examples/govt_scheme_summarizer/.gitignore`.

## Tests

Written before the fixes and watched failing. **87 passing, up from 82.**

## Checks

```
python3 -m pytest tests/ -q                                          87 passed
python3 scripts/ci_validate.py --base-ref main                       PASS, 0 errors
python3 scripts/validate_recipe.py examples/govt_scheme_summarizer --strict   PASS
```

## Two judgement calls, flagged rather than buried

A malformed pin is reported as an **error** rather than silently skipped, so a contributor who typos a version still learns about it.

The Pillow branch carried the identical crash and is fixed alongside `sarvamai`. Leaving it would have shipped a half-fix. Happy to trim to just the one line if you would rather.

## Overlap

PRs #124 and #142 also touch this file, but only in the secret-scanning region — `_SECRET_RE` and `check_secrets`. Neither touches `check_requirements` or `auto_fix`. Should merge in any order.