### PR TITLE
fix(ci): scan files whose names are not ASCII

### DIFF
--- a/scripts/ci_validate.py
+++ b/scripts/ci_validate.py
@@ -34,7 +34,7 @@ def _issue_dict(issue: Issue) -> dict:
 def changed_recipe_dirs(base_ref: str, head_ref: str = "HEAD") -> list[Path]:
     for ref_pair in (f"origin/{base_ref}...{head_ref}", f"{base_ref}...{head_ref}"):
         result = subprocess.run(
-            ["git", "diff", "--name-only", ref_pair],
+            ["git", "-c", "core.quotePath=false", "diff", "--name-only", ref_pair],
             capture_output=True,
             text=True,
             check=False,

--- a/scripts/sarvam_checks.py
+++ b/scripts/sarvam_checks.py
@@ -141,7 +141,7 @@ def git_diff_name_only(base_ref: str, head_ref: str = "HEAD") -> list[str]:
     """Return changed file paths between base_ref and head_ref."""
     for ref_pair in (f"origin/{base_ref}...{head_ref}", f"{base_ref}...{head_ref}"):
         result = subprocess.run(
-            ["git", "diff", "--name-only", "--diff-filter=ACMRT", ref_pair],
+            ["git", "-c", "core.quotePath=false", "diff", "--name-only", "--diff-filter=ACMRT", ref_pair],
             capture_output=True,
             text=True,
             check=False,

--- a/tests/test_git_paths.py
+++ b/tests/test_git_paths.py
@@ -1,0 +1,77 @@
+"""Tests that git helpers return usable paths for non-ASCII filenames.
+
+Git quotes and octal-escapes paths containing non-ASCII bytes by default, so
+`git diff --name-only` reports `leak_हिंदी.py` as
+`"examples/demo/leak_\\340\\244\\271...py"`. A path in that form no longer
+starts with `examples/`, so every downstream prefix check drops it and the file
+is silently never scanned. This repo is about Indian languages, so a recipe
+named in an Indic script is a realistic contribution.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import ci_validate  # noqa: E402
+import validate_pr  # noqa: E402
+from sarvam_checks import git_diff_name_only  # noqa: E402
+
+RECIPE_DIR = "examples/हिंदी-recipe"
+LEAK_FILE = f"{RECIPE_DIR}/leak_हिंदी.py"
+LEAK_LINE = 'SARVAM_API_KEY = "sarvam_fake_key_abcdefghijklmnopqrst"\n'
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture
+def devanagari_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A real git repo whose feature branch adds a Devanagari-named recipe."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    # Git's default, set explicitly so this test still exercises the quoting
+    # path on machines whose global config already disables it.
+    _git(repo, "config", "core.quotepath", "true")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+
+    _git(repo, "checkout", "-q", "-b", "feature")
+    recipe = repo / RECIPE_DIR
+    recipe.mkdir(parents=True)
+    (recipe / ".env.example").write_text("SARVAM_API_KEY=your-sarvam-api-key\n", encoding="utf-8")
+    (recipe / "demo.ipynb").write_text(
+        '{"cells": [], "nbformat": 4, "nbformat_minor": 5}\n', encoding="utf-8"
+    )
+    (repo / LEAK_FILE).write_text(LEAK_LINE, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add recipe")
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(validate_pr, "REPO_ROOT", repo)
+    monkeypatch.setattr(ci_validate, "REPO_ROOT", repo)
+    return repo
+
+
+class TestNonAsciiPaths:
+    def test_diff_returns_unquoted_path(self, devanagari_repo: Path) -> None:
+        assert LEAK_FILE in git_diff_name_only("main")
+
+    def test_non_ascii_file_stays_in_scan_scope(self, devanagari_repo: Path) -> None:
+        assert Path(LEAK_FILE) in validate_pr.changed_paths("main")
+
+    def test_leak_in_non_ascii_file_is_flagged(self, devanagari_repo: Path) -> None:
+        issues = validate_pr.validate_pr_with_refs("main")
+        assert any(i.check == "secrets" and "हिंदी" in i.message for i in issues)
+
+    def test_non_ascii_recipe_dir_is_validated(self, devanagari_repo: Path) -> None:
+        assert ci_validate.changed_recipe_dirs("main") == [Path(RECIPE_DIR)]


### PR DESCRIPTION
## The bug

Git quotes and octal-escapes non-ASCII paths by default. A file named in Devanagari comes back from `git diff --name-only` like this:

```
examples/demo/leak_ascii.py
"examples/demo/leak_\340\244\271\340\244\277\340\244\202\340\244\246\340\245\200.py"
```

The second is `leak_हिंदी.py`. Because that string starts with a double quote, the prefix check in `validate_pr.py` does not recognise it as being under `examples/`, and the file is dropped before any scan runs:

```
'examples/demo/leak_ascii.py'.startswith(SCAN_PREFIXES)   -> True
'"examples/demo/leak_\\340\\244...py"'.startswith(...)     -> False
'examples/demo/leak_हिंदी.py'.startswith(SCAN_PREFIXES)    -> True   (unquoted works)
```

`changed_recipe_dirs` in `ci_validate.py` had the same problem — its `parts[0] == "examples"` check sees `"examples` with the leading quote.

## End to end

A throwaway repo with a branch adding `examples/हिंदी-recipe/leak_हिंदी.py` containing a fake key:

```
BEFORE   changed_paths: []   changed_recipe_dirs: []   issues found: 0
AFTER    changed_paths: [3 files]   changed_recipe_dirs: [examples/हिंदी-recipe]   issues found: 8
```

Before the change the leaked key passed CI silently.

## The fix

`-c core.quotePath=false` on the two git calls that parse path output — `git_diff_name_only` in `sarvam_checks.py` and `changed_recipe_dirs` in `ci_validate.py`. Two lines.

`git_diff_added_lines` deliberately left alone: `core.quotePath` only affects the `---`/`+++` header lines, which its parser already skips, and the path it takes is a caller-supplied pathspec rather than parsed output. Verified it already behaves correctly.

## Why it is worth fixing while it is still latent

`git ls-files | LC_ALL=C grep -c '[^ -~]'` returns 0, so nothing in the repo has a non-ASCII name today. But this is a cookbook about Indian languages. A contributor naming a file in an Indian script is expected rather than exotic, and their leaked key would have gone unnoticed.

## Tests

New file `tests/test_git_paths.py` — 4 tests over a real temporary git repo with real git commands, written before the fix and watched failing. They set `core.quotepath true` explicitly so the bug is still exercised on a machine whose global config disables quoting. **86 passing, up from 82.**

```
python3 -m pytest tests/ -q                      86 passed
python3 scripts/ci_validate.py --base-ref main   PASS, 0 errors
```

Tests went in a new file on purpose: #141, #142 and #147 all append to `tests/test_validate_pr.py`, and a fourth appender would guarantee a conflict.

## Overlap

Checked #141, #142 and #147 hunk by hunk. None touches `git_diff_name_only` or `git_diff_added_lines` — the nearest hunk in #147 ends six lines short. #147 refactors `changed_paths` to call `is_scanned_path`, which still calls `git_diff_name_only`, so it inherits this fix cleanly.