### PR TITLE
fix(examples): install audioop-lts so pydub works on Python 3.13

### DIFF
--- a/examples/converting_wav_into_mp3/wav_to_mp3.ipynb
+++ b/examples/converting_wav_into_mp3/wav_to_mp3.ipynb
@@ -50,21 +50,13 @@
         "id": "CXBVuI4v6TPM",
         "outputId": "5b5fb3d2-529c-4e57-cb4b-0bb500a39c5e"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Collecting pydub\n",
-            "  Downloading pydub-0.25.1-py2.py3-none-any.whl.metadata (1.4 kB)\n",
-            "Downloading pydub-0.25.1-py2.py3-none-any.whl (32 kB)\n",
-            "Installing collected packages: pydub\n",
-            "Successfully installed pydub-0.25.1\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
-        "!pip install pydub\n",
+        "!pip install pydub \"audioop-lts; python_version >= '3.13'\"\n",
+        "\n",
+        "# Python 3.13 removed the built-in audioop module that pydub needs, so the line\n",
+        "# above also installs audioop-lts, which puts it back. On Python 3.12 and older\n",
+        "# pip skips it and nothing changes.\n",
         "\n",
         "# pydub uses ffmpeg under the hood for MP3 export.\n",
         "# Google Colab / Debian Linux: uncomment the next line to install it.\n",


### PR DESCRIPTION
## The bug

`examples/converting_wav_into_mp3/wav_to_mp3.ipynb` cannot run on Python 3.13. Its only real code cell dies on the import.

Python 3.13 removed the stdlib `audioop` module (PEP 594), and `pydub` depends on it. In a clean 3.13.0 venv with `pip install pydub`:

```
File ".../pydub/utils.py", line 16, in <module>
    import pyaudioop as audioop
ModuleNotFoundError: No module named 'pyaudioop'
```

This is not hypothetical — the machine I am writing this on runs 3.13.12, and `import audioop` fails there.

## Why this fix and not another

I checked what the notebook actually does with `AudioSegment` before choosing: it calls `from_wav()` then `export(..., format="mp3")`. That is a real re-encode, not a container swap, so the stdlib `wave` module cannot replace it. Dropping pydub would mean shelling out to ffmpeg directly, which rewrites the recipe's premise — its title, prose and code all say "using the `pydub` library". That is a direction change, not a bug fix, and not mine to make.

`audioop-lts` is the drop-in replacement for exactly the module PEP 594 removed. It is a wheel with no further dependencies, and the version marker means Python 3.12 and older install precisely what they did before.

**New dependency surface on old Python: zero. On 3.13: one small wheel.** The notebook's code is untouched.

## Verified on real interpreters

Fresh 3.13.0 venv, install line read straight out of the fixed notebook:

```
$ pip install pydub "audioop-lts; python_version >= '3.13'"
Successfully installed audioop-lts-0.2.2 pydub-0.25.1

--- the notebook's code cell, verbatim ---
Conversion complete!
output_file.mp3: Audio file with ID3 version 2.4.0, contains: MPEG ADTS, layer III, v1, 56 kbps, 44.1 kHz, Monaural
```

On Python 3.12.4 the marker correctly skips it:

```
Ignoring audioop-lts: markers 'python_version >= "3.13"' don't match your environment
AudioSegment imported OK on 3.12.4 - stdlib audioop: audioop
```

## One thing I changed that is worth knowing

I cleared the stored output on the install cell, because it was a log of the **old** command and no truthful replacement can be produced without running it. The other code cell's source is unchanged, so its existing `Conversion complete!` output was left as it was.

## Checks

```
every code cell compiled before and after     0 failures
python3 -m pytest tests/ -q                   82 passed
python3 scripts/ci_validate.py --base-ref main  PASS, 0 errors
```

## Overlap

No open PR touches this notebook. #60 adds a `README.md` to the same directory — a new file, not this one; both can merge in either order.