### PR TITLE
fix(getting-started): import AudioSegment so the split step runs

### DIFF
--- a/getting-started/stt-translate/stt-translate-batch-api/Sarvam_STT_Translate_Batch_API_Demo.ipynb
+++ b/getting-started/stt-translate/stt-translate-batch-api/Sarvam_STT_Translate_Batch_API_Demo.ipynb
@@ -68,7 +68,7 @@
     "outputId": "4ba0458e-c013-42af-fce3-c343a268eaaa"
    },
    "outputs": [],
-   "source": "!pip install azure-storage-file-datalake aiofiles aiohttp requests pydub"
+   "source": "!pip install azure-storage-file-datalake aiofiles aiohttp requests pydub \"audioop-lts; python_version >= '3.13'\"\n\n# Python 3.13 removed the built-in audioop module that pydub needs, so the line\n# above also installs audioop-lts, which puts it back. On Python 3.12 and older\n# pip skips it and nothing changes."
   },
   {
    "cell_type": "markdown",
@@ -86,7 +86,7 @@
     "id": "FFILCZmMvcjm"
    },
    "outputs": [],
-   "source": "import asyncio\nimport aiofiles\nimport requests\nimport json\nimport io\nfrom urllib.parse import urlparse\nfrom azure.storage.filedatalake.aio import DataLakeDirectoryClient, FileSystemClient\nfrom azure.storage.filedatalake import ContentSettings\nimport mimetypes\nimport logging\nfrom pprint import pprint\nimport os\n\nlogging.basicConfig(\n    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n)\nlogger = logging.getLogger(__name__)\n\n# Configuration\nAPI_SUBSCRIPTION_KEY = \"YOUR_SARVAM_API_KEY\""
+   "source": "import asyncio\nimport aiofiles\nimport requests\nimport json\nimport io\nfrom urllib.parse import urlparse\nfrom azure.storage.filedatalake.aio import DataLakeDirectoryClient, FileSystemClient\nfrom azure.storage.filedatalake import ContentSettings\nimport mimetypes\nimport logging\nfrom pprint import pprint\nimport os\nfrom pydub import AudioSegment\n\nlogging.basicConfig(\n    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n)\nlogger = logging.getLogger(__name__)\n\n# Configuration\nAPI_SUBSCRIPTION_KEY = \"YOUR_SARVAM_API_KEY\""
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## The bug

`getting-started/stt-translate/stt-translate-batch-api/Sarvam_STT_Translate_Batch_API_Demo.ipynb` installs `pydub` but never imports `AudioSegment`, so the chunking helper fails the moment it is called:

```
    audio = AudioSegment.from_file(audio_path)  # Load the audio file
NameError: name 'AudioSegment' is not defined
```

Reproduced by executing cell 15 and calling `split_audio('x.wav', 60000)`. `from pydub import AudioSegment` appears nowhere in the notebook.

Long audio has to be split before it is submitted, so this is on the main path of the recipe, not a corner of it.

## Two lines, not one, and why

The missing import alone does not make the notebook run on current Python. `pydub` needs the stdlib `audioop` module, which Python 3.13 removed (PEP 594), so fixing the import just moves the failure:

```
NameError: name 'AudioSegment' is not defined
    ->  ModuleNotFoundError: No module named 'pyaudioop'
```

So the install cell also gains `audioop-lts` behind a version marker. On Python 3.12 and older pip skips it and nothing changes. Without it I could not have verified this fix by running the notebook's own cells, which felt like the wrong place to stop.

If you would rather have the strict one-line import fix, that hunk can be dropped and the import edit stands on its own. Same reasoning and same package as #160, deliberately, so the two notebooks do not diverge.

## Verified

Fresh 3.13.0 venv built by running this notebook's own install cell, then executing cell 6 and cell 15 verbatim against a 180-second wav:

```
=== BEFORE ===
NameError: name 'AudioSegment' is not defined

=== AFTER ===
chunk count: 3
chunk lengths in ms: [60000, 60000, 60000]
```

## Scope

Two `source` strings. The import is appended, nothing reordered. `class SarvamClient` is untouched — unlike the STT batch demo next door, this notebook's class header is intact. All 8 code cells still have zero outputs.

```
every code cell compiled before and after     0 failures
python3 -m pytest tests/ -q                   82 passed
python3 scripts/ci_validate.py --base-ref main  PASS, 0 errors
```

## Overlap

No open PR touches this file. #92 lists the **pre-rename** `notebooks/...` path — its branch predates the `notebooks/` to `getting-started/` move, it touches no `getting-started/` paths, and GitHub already reports it CONFLICTING. Not a competing fix.

A search across issues and PRs for `pydub`, `audioop` and `AudioSegment` returns nothing, so neither this nor #160 has been reported by anyone else.