### PR TITLE
fix(ci): report validation failures instead of passing silently

### DIFF
--- a/scripts/ci_validate.py
+++ b/scripts/ci_validate.py
@@ -12,12 +12,19 @@ import argparse
 import json
 import subprocess
 import sys
+import traceback
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from sarvam_checks import Issue, is_recipe_directory  # noqa: E402
+from sarvam_checks import (  # noqa: E402
+    GitDiffError,
+    Issue,
+    git_diff_issue,
+    git_failure_reason,
+    is_recipe_directory,
+)
 from validate_pr import validate_pr_with_refs  # noqa: E402
 from validate_recipe import validate_recipe  # noqa: E402
 
@@ -40,6 +47,7 @@ def changed_recipe_dirs(base_ref: str, head_ref: str = "HEAD") -> list[Path]:
             check=False,
         )
         if result.returncode != 0:
+            failure = git_failure_reason(result)
             continue
         dirs: set[str] = set()
         for path in result.stdout.splitlines():
@@ -49,7 +57,9 @@ def changed_recipe_dirs(base_ref: str, head_ref: str = "HEAD") -> list[Path]:
                 if is_recipe_directory(candidate):
                     dirs.add(f"examples/{parts[1]}")
         return sorted(Path(d) for d in dirs)
-    return []
+    raise GitDiffError(
+        f"could not diff origin/{base_ref}...{head_ref} or {base_ref}...{head_ref}: {failure}"
+    )
 
 
 def run_validation(base_ref: str, head_ref: str = "HEAD") -> list[Issue]:
@@ -67,7 +77,23 @@ def main() -> int:
     parser.add_argument("--output", help="Write JSON issues to this file")
     args = parser.parse_args()
 
-    issues = run_validation(args.base_ref, args.head_ref)
+    try:
+        issues = run_validation(args.base_ref, args.head_ref)
+    except GitDiffError as exc:
+        issues = [git_diff_issue(args.base_ref, exc)]
+    except Exception as exc:  # noqa: BLE001 - a crash must still reach the contributor
+        # Without this the run dies before writing --output, the comment step
+        # then fails on the missing file, and nobody is told what went wrong.
+        traceback.print_exc()
+        issues = [Issue(
+            "error",
+            "validator-crashed",
+            f"Validation stopped early: {type(exc).__name__}: {exc}. "
+            "The checks after this point did not run.",
+            "This is a bug in the validator, not necessarily in your PR. "
+            "Please report it with the run log attached.",
+        )]
+
     payload = [_issue_dict(i) for i in issues]
     errors = [i for i in issues if i.severity == "error"]
 

--- a/scripts/pr_comment.py
+++ b/scripts/pr_comment.py
@@ -64,7 +64,20 @@ def main() -> int:
     parser.add_argument("--output", help="Write comment to file instead of stdout")
     args = parser.parse_args()
 
-    data = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    try:
+        raw = Path(args.input).read_text(encoding="utf-8")
+    except OSError as exc:
+        # Usually means the validation step died before writing its results.
+        # Say so plainly instead of ending the job on a traceback.
+        print(f"Cannot read validation results file {args.input}: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"Validation results file {args.input} is not valid JSON: {exc}", file=sys.stderr)
+        return 1
+
     comment = format_ci_comment(data)
     if args.output:
         Path(args.output).write_text(comment, encoding="utf-8")

--- a/scripts/sarvam_checks.py
+++ b/scripts/sarvam_checks.py
@@ -137,8 +137,46 @@ def should_scan_file(path: Path) -> bool:
 # ---------------------------------------------------------------------------
 
 
+class GitDiffError(RuntimeError):
+    """Raised when git could not produce a diff, so the changed set is unknown.
+
+    An empty list means "nothing changed" and is a valid, checked result.
+    A bad base ref or a non-repo working directory is not that — it means no
+    file was examined at all, which must never be reported as a clean scan.
+    """
+
+
+def git_diff_issue(base_ref: str, exc: GitDiffError) -> Issue:
+    """Turn a failed diff into a blocking finding.
+
+    Both entry points need this: a run that could not list the changed files
+    has checked nothing, and must say so instead of exiting 0.
+    """
+    return Issue(
+        "error",
+        "git-diff",
+        f"Could not work out which files changed, so nothing was checked — {exc}",
+        f"Check that {base_ref} exists here and that the checkout has enough "
+        "history (actions/checkout needs fetch-depth: 0).",
+    )
+
+
+def git_failure_reason(result: subprocess.CompletedProcess) -> str:
+    """Return git's own one-line reason for failing.
+
+    Only the first line: the rest of git's stderr is usage help, and these
+    messages end up in a one-line ``::error ::`` annotation and in a PR comment.
+    """
+    lines = result.stderr.strip().splitlines()
+    return lines[0] if lines else f"git exited {result.returncode}"
+
+
 def git_diff_name_only(base_ref: str, head_ref: str = "HEAD") -> list[str]:
-    """Return changed file paths between base_ref and head_ref."""
+    """Return changed file paths between base_ref and head_ref.
+
+    Raises:
+        GitDiffError: if git failed for every candidate ref pair.
+    """
     for ref_pair in (f"origin/{base_ref}...{head_ref}", f"{base_ref}...{head_ref}"):
         result = subprocess.run(
             ["git", "diff", "--name-only", "--diff-filter=ACMRT", ref_pair],
@@ -148,11 +186,21 @@ def git_diff_name_only(base_ref: str, head_ref: str = "HEAD") -> list[str]:
         )
         if result.returncode == 0:
             return [line.strip() for line in result.stdout.splitlines() if line.strip()]
-    return []
+        failure = git_failure_reason(result)
+    raise GitDiffError(
+        f"could not diff origin/{base_ref}...{head_ref} or {base_ref}...{head_ref}: {failure}"
+    )
 
 
 def git_diff_added_lines(base_ref: str, file_path: str, head_ref: str = "HEAD") -> list[tuple[int, str]]:
-    """Return (line_number, content) for lines added in file_path."""
+    """Return (line_number, content) for lines added in file_path.
+
+    Raises:
+        GitDiffError: if git failed for every candidate ref pair. A ref pair
+            that diffed successfully but added nothing still returns [].
+    """
+    diffed = False
+    failure = ""
     for ref_pair in (f"origin/{base_ref}...{head_ref}", f"{base_ref}...{head_ref}"):
         result = subprocess.run(
             ["git", "diff", "-U0", ref_pair, "--", file_path],
@@ -161,7 +209,9 @@ def git_diff_added_lines(base_ref: str, file_path: str, head_ref: str = "HEAD") 
             check=False,
         )
         if result.returncode != 0:
+            failure = git_failure_reason(result)
             continue
+        diffed = True
 
         added: list[tuple[int, str]] = []
         current_line = 0
@@ -180,6 +230,11 @@ def git_diff_added_lines(base_ref: str, file_path: str, head_ref: str = "HEAD") 
                 current_line += 1
         if added or result.stdout:
             return added
+    if not diffed:
+        raise GitDiffError(
+            f"could not diff origin/{base_ref}...{head_ref} or "
+            f"{base_ref}...{head_ref} for {file_path}: {failure}"
+        )
     return []
 
 

--- a/scripts/validate_pr.py
+++ b/scripts/validate_pr.py
@@ -22,7 +22,9 @@ import sys
 from pathlib import Path
 
 from sarvam_checks import (
+    GitDiffError,
     Issue,
+    git_diff_issue,
     git_diff_name_only,
     scan_file_for_client_side_keys,
     scan_file_for_secrets,
@@ -86,7 +88,11 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    issues = validate_pr(args.base_ref)
+    try:
+        issues = validate_pr(args.base_ref)
+    except GitDiffError as exc:
+        issues = [git_diff_issue(args.base_ref, exc)]
+
     errors = [i for i in issues if i.severity == "error"]
     warnings = [i for i in issues if i.severity == "warning"]
 

--- a/tests/test_ci_failure_reporting.py
+++ b/tests/test_ci_failure_reporting.py
@@ -1,0 +1,210 @@
+"""Tests that a validator which cannot do its job says so.
+
+Every case in this file is the same failure: something stopped a check from
+running, and the script reported success anyway. A run that cannot work out
+which files changed, or that dies partway through, has not validated anything
+— so it must print a visible error and write one into the results file, never
+a PASS and never an empty list.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import ci_validate  # noqa: E402
+import pr_comment  # noqa: E402
+import validate_pr  # noqa: E402
+from sarvam_checks import (  # noqa: E402
+    GitDiffError,
+    git_diff_added_lines,
+    git_diff_name_only,
+)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A real single-commit git repo, made the current working directory."""
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    _git(r, "config", "user.email", "test@example.com")
+    _git(r, "config", "user.name", "Test")
+    (r / "README.md").write_text("base\n", encoding="utf-8")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "base")
+    monkeypatch.chdir(r)
+    return r
+
+
+class TestCiValidateUnknownChangedSet:
+    """Bug A: an unresolvable base ref printed PASS and wrote an empty file."""
+
+    def test_unresolvable_base_ref_does_not_report_pass(
+        self, repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        out = tmp_path / "results.json"
+        monkeypatch.setattr(
+            sys, "argv",
+            ["ci_validate.py", "--base-ref", "no-such-ref-xyz", "--output", str(out)],
+        )
+        exit_code = ci_validate.main()
+        printed = capsys.readouterr().out
+        assert "PASS" not in printed
+        assert exit_code == 1
+
+    def test_unresolvable_base_ref_writes_an_error_to_the_results_file(
+        self, repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        out = tmp_path / "results.json"
+        monkeypatch.setattr(
+            sys, "argv",
+            ["ci_validate.py", "--base-ref", "no-such-ref-xyz", "--output", str(out)],
+        )
+        ci_validate.main()
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        assert [i for i in payload if i["severity"] == "error"], payload
+
+
+class TestGitDiffFailureIsVisible:
+    """Bug B: git failing looked exactly like a clean scan of zero files."""
+
+    def test_name_only_raises_on_unresolvable_base_ref(self, repo: Path) -> None:
+        with pytest.raises(GitDiffError):
+            git_diff_name_only("no-such-ref-xyz")
+
+    def test_name_only_raises_outside_a_git_repo(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        outside = tmp_path / "not-a-repo"
+        outside.mkdir()
+        monkeypatch.chdir(outside)
+        with pytest.raises(GitDiffError):
+            git_diff_name_only("main")
+
+    def test_name_only_returns_empty_when_nothing_changed(self, repo: Path) -> None:
+        # The other half of the contract: a real, successful diff with no
+        # changes must still be an empty list, not an error. This also covers
+        # the origin/<ref> attempt failing before the plain <ref> one succeeds.
+        assert git_diff_name_only("main") == []
+
+    def test_added_lines_raises_on_unresolvable_base_ref(self, repo: Path) -> None:
+        with pytest.raises(GitDiffError):
+            git_diff_added_lines("no-such-ref-xyz", "README.md")
+
+    def test_added_lines_returns_empty_when_nothing_changed(self, repo: Path) -> None:
+        assert git_diff_added_lines("main", "README.md") == []
+
+    def test_validate_pr_does_not_report_pass_on_unresolvable_base_ref(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setattr(
+            sys, "argv", ["validate_pr.py", "--base-ref", "no-such-ref-xyz"],
+        )
+        exit_code = validate_pr.main()
+        printed = capsys.readouterr().out
+        assert "PASS" not in printed
+        assert exit_code == 1
+
+
+class TestCiValidateSurvivesACrash:
+    """Bug C: a crash inside a checker left no results file at all.
+
+    The workflow runs ci_validate.py with continue-on-error, so the job carried
+    on to the comment step, which then failed on a second and unrelated error
+    (a missing input file). The contributor got no comment and never learned
+    the real cause. The crash is deliberately a plain exception here rather
+    than the malformed version pin that first triggered it: the point is that
+    any crash must be reported, not that one particular input is handled.
+    """
+
+    def _run_with_crash(
+        self, exc: Exception, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> tuple[int, Path]:
+        def boom(*args: object, **kwargs: object) -> list:
+            raise exc
+
+        out = tmp_path / "results.json"
+        monkeypatch.setattr(ci_validate, "run_validation", boom)
+        monkeypatch.setattr(
+            sys, "argv",
+            ["ci_validate.py", "--base-ref", "main", "--output", str(out)],
+        )
+        return ci_validate.main(), out
+
+    def test_crash_still_writes_an_error_to_the_results_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        exit_code, out = self._run_with_crash(
+            ValueError("Invalid version: '0.1.24.'"), tmp_path, monkeypatch,
+        )
+        assert exit_code == 1
+        assert out.exists(), "no results file was written, so no comment can be built"
+        payload = json.loads(out.read_text(encoding="utf-8"))
+        assert [i for i in payload if i["severity"] == "error"], payload
+
+    def test_crash_report_names_the_underlying_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _, out = self._run_with_crash(
+            ValueError("Invalid version: '0.1.24.'"), tmp_path, monkeypatch,
+        )
+        blob = out.read_text(encoding="utf-8")
+        assert "ValueError" in blob
+        assert "0.1.24." in blob
+
+    def test_crash_does_not_report_pass(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        self._run_with_crash(RuntimeError("boom"), tmp_path, monkeypatch)
+        assert "PASS" not in capsys.readouterr().out
+
+
+class TestPrCommentUnreadableInput:
+    """Bug D: a missing results file ended in a traceback.
+
+    This is reached for real whenever bug C happens, and it is the step that
+    was supposed to tell the contributor what went wrong.
+    """
+
+    def _run(
+        self, path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> int:
+        monkeypatch.setattr(sys, "argv", ["pr_comment.py", "--input", str(path)])
+        return pr_comment.main()
+
+    def test_missing_input_reports_instead_of_crashing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        missing = tmp_path / "validation-results.json"
+        exit_code = self._run(missing, monkeypatch)
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert str(missing) in captured.err
+        # It must not fall through and render the "everything passed" comment.
+        assert "passed" not in captured.out.lower()
+
+    def test_unreadable_input_reports_instead_of_crashing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        bad = tmp_path / "validation-results.json"
+        bad.write_text("this is not json\n", encoding="utf-8")
+        exit_code = self._run(bad, monkeypatch)
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert str(bad) in captured.err
+        assert "passed" not in captured.out.lower()


### PR DESCRIPTION
Four ways the validator could fail to do its job and still report success. They are one theme, which is why they are one pull request.

## The four

**An unresolvable base ref reports PASS.**
```
$ python3 scripts/ci_validate.py --base-ref this-ref-does-not-exist-12345
PASS — 0 error(s), 0 warning(s)     exit 0     results file: []
```

**A git failure is indistinguishable from a clean scan.**
```
$ python3 scripts/validate_pr.py --base-ref no-such-ref-xyz
PASS — no PR validation issues found.     exit 0
```
Underneath, git exits 128 and `git_diff_name_only` returns `[]` — the same value it returns when there really are no changes.

**A crash produces no feedback at all.** A recipe with `sarvamai>=0.1.24.` made `ci_validate.py` die before writing `validation-results.json`. `continue-on-error: true` let the job carry on, the comment step then failed on the missing file, and the contributor got a red cross and no explanation. To the workflow, "found errors" and "crashed" are both `outcome == 'failure'`.

**`pr_comment.py` raised `FileNotFoundError`** on a missing input — reached for real whenever the above happens.

## After

```
$ python3 scripts/ci_validate.py --base-ref this-ref-does-not-exist-12345
FAIL — 1 error(s), 0 warning(s)

$ python3 scripts/validate_pr.py --base-ref no-such-ref-xyz
FAIL — 1 error(s), 0 warning(s)

$ python3 scripts/pr_comment.py --input /tmp/definitely-missing.json
Cannot read validation results file /tmp/definitely-missing.json: [Errno 2] No such file or directory
```

## The design

One exception, `GitDiffError`, and two small helpers.

The git helpers **raise** when git failed for every ref pair, and still **return `[]`** when git succeeded and there genuinely were no changes. That distinction is the entire fix. Both entry points catch it and turn it into an ordinary blocking `Issue`, so the text output, `--json`, the `::error ::` annotation and the results file all keep working unchanged.

`ci_validate.main` also has a catch-all: a crash prints its traceback to the run log **and** writes a real error into the JSON, so the file always exists for the comment step.

git's stderr is trimmed to its first line — the full multi-line usage dump broke both the one-line annotation and the comment markdown.

## Tests

13 new tests in a **new** file, `tests/test_ci_failure_reporting.py`. New rather than appended, because three open PRs already rewrite `tests/test_validate_pr.py`.

Written before the fixes and watched failing. Sample RED output:

```
Failed: DID NOT RAISE <class 'sarvam_checks.GitDiffError'>
assert 'PASS' not in 'PASS — no PR validation issues found.'
RuntimeError: boom          # escaped main() entirely, no results file
```

**95 passed**, up from 82.

The crash test uses a plain exception rather than the malformed pin, deliberately — the point is that *any* crash is reported. I re-verified the real trigger end to end separately: a recipe with `sarvamai>=0.1.24.` now writes `validator-crashed / InvalidVersion` into the JSON and `pr_comment.py` renders a real comment.

## Overlap — merge-tested, not eyeballed

I cloned upstream, applied this as a commit, fetched each PR head and ran a real `git merge`.

| PR | Result |
|---|---|
| #147, #152, #155, #156 (mine) | **clean** |
| #132 | **clean** |
| #141, #142 | **conflict** |

All four of my open PRs merged together with this change give **118 passing tests**.

**#156 is compatible by construction.** It edits the `["git", ...]` argument line inside the same two functions I change. I left the `for` line and the `subprocess.run(...)` block byte-identical so its hunks still apply cleanly.

**#155 is complementary, not redundant.** It removes one *trigger* of the crash. The catch-all here is what makes any future crash visible.

## One thing worth a maintainer's attention

**#141 and #142 add a test that asserts this bug is correct behaviour:**

```python
def test_git_failure_returns_empty(self, mock_run):
    mock_run.return_value = MagicMock(returncode=1, stderr="fatal: bad revision")
    assert git_diff_added_lines("main", "examples/foo/app.py") == []
```

That asserts a git *failure* should look like *no changes*. Documenting observed behaviour is a reasonable thing to do if you do not know the behaviour is wrong, so this is not a criticism — but if either lands first, the bug becomes a tested guarantee.

I resolved #141's textual conflicts locally and ran the merged suite: **143 passed, 1 failed — exactly that test.** Whoever lands second changes those three lines to `pytest.raises(GitDiffError)`. I also shrank my side of the conflict from 11 lines to 4 by routing both entry points through a shared helper.

Worth noting #141 and #142 are near-duplicates by the same author, #142 a superset of #141, and they conflict with each other — so at most one can land regardless.

## Scope note

`git_diff_added_lines` has **no caller on main today**; #141 and #142 introduce the first one. So that half of this fix is currently latent and matters the moment either lands.