### PR TITLE
revert: remove shift-left-security gate (blocking all PRs)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -19,19 +19,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  shift-left-security:
-    uses: sarvamai/security-redirect/.github/workflows/security-redirect.yml@v2
-    with:
-      dockerfile_path: ''
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-      pull-requests: write
-
   validate:
     name: Validate PR
-    needs: shift-left-security
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Reverts #164 (`shift-left-security` job added to `pr-check.yml`).

The reusable workflow call to
`sarvamai/security-redirect/.github/workflows/security-redirect.yml@v2`
fails to dispatch entirely — every run against it produces 0 jobs and
0 check-runs, with GitHub reporting "This run likely failed because of
a workflow file issue" (see [run 33059780392](https://github.com/sarvamai/sarvam-ai-cookbook/actions/runs/33059780392)
and [run 33059998440](https://github.com/sarvamai/sarvam-ai-cookbook/actions/runs/33059998440),
the latter on a fresh commit pushed *after* #164 merged, ruling out a
"file not yet on base branch" issue).

Since `validate` in `pr-check.yml` has `needs: shift-left-security`,
this means **every PR against this repo currently fails CI**,
regardless of content — see #165.

Most likely cause: `security-redirect`'s repo-level Access setting
(Settings → Actions → General → Access) doesn't yet permit other
`sarvamai` org repos to call it as a reusable workflow. That's outside
what this repo can fix — whoever owns `security-redirect` needs to
check it.

## This PR

Removes the `shift-left-security` job and the `needs:` dependency on
`validate`, restoring `pr-check.yml` to its pre-#164 state, so
contributor PRs can pass CI again. Re-add once the access issue on
`security-redirect` is confirmed fixed (test against #165 first
before re-merging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)