### PR TITLE
Add issue templates to route product/API bugs away from this repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-example.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report-example.yml
@@ -1,0 +1,64 @@
+name: "Bug report: example in this repo"
+description: "Report a problem with code, a notebook, or a recipe in this repository."
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug!
+
+        **Before you continue:** this repo only contains example code and notebooks for the Sarvam AI API. If your issue is actually about the **Indus app**, **Creator Studio**, the **Sarvam API/product itself**, or your **account/billing**, please close this and use the links on the "New issue" chooser page instead — a maintainer here can't fix those from this repository.
+
+  - type: input
+    id: example-path
+    attributes:
+      label: Which example, notebook, or script?
+      description: "Path in the repo, e.g. examples/Realtime_Speech_Captioning/app.py"
+      placeholder: "examples/.../..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: "Describe the bug. Include the exact error message if there is one, and which model/endpoint you were calling."
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen instead?
+    validations:
+      required: false
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: "Minimal steps so a maintainer can reproduce it."
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: "Python version, OS, and sarvamai SDK version if relevant."
+      placeholder: "e.g. Python 3.11, macOS, sarvamai==x.y.z"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: "This is about example code in this repository — not the Indus app, Creator Studio, or the Sarvam API/product itself."
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,19 @@
+# Placeholder contact links — see issue #149.
+# Each url below currently points at #149 as an interim placeholder.
+# Replace with the real destinations once the team confirms them, then
+# delete this comment block.
+
+blank_issues_enabled: false
+contact_links:
+  - name: 🐛 Bug in the Indus app
+    url: https://github.com/sarvamai/sarvam-ai-cookbook/issues/149
+    about: "This repo only covers example code, not the Indus app. (Placeholder link — see #149.)"
+  - name: 🎬 Bug in Creator Studio
+    url: https://github.com/sarvamai/sarvam-ai-cookbook/issues/149
+    about: "This repo only covers example code, not Creator Studio. (Placeholder link — see #149.)"
+  - name: ⚙️ Sarvam API, product, or account issue
+    url: https://github.com/sarvamai/sarvam-ai-cookbook/issues/149
+    about: "For API behavior, billing, or account/dashboard issues, not this repo's example code. (Placeholder link — see #149.)"
+  - name: 📚 Sarvam AI documentation
+    url: https://docs.sarvam.ai
+    about: "General docs and API reference."

--- a/.github/ISSUE_TEMPLATE/recipe-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/recipe-proposal.yml
@@ -1,7 +1,7 @@
 name: "Recipe / example proposal"
 description: "Propose a new notebook, script, or end-to-end example for the cookbook."
 title: "[Recipe]: "
-labels: ["enhancement", "new-recipe"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/recipe-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/recipe-proposal.yml
@@ -1,0 +1,59 @@
+name: "Recipe / example proposal"
+description: "Propose a new notebook, script, or end-to-end example for the cookbook."
+title: "[Recipe]: "
+labels: ["enhancement", "new-recipe"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for a new example that would help other developers? Tell us about it here. If you'd like to build it yourself, say so below — see CONTRIBUTING.md for the template and structure to use.
+
+  - type: input
+    id: recipe-name
+    attributes:
+      label: Proposed recipe name
+      placeholder: "e.g. Streaming chat example for Sarvam API"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: api-area
+    attributes:
+      label: Which Sarvam API area does this cover?
+      multiple: true
+      options:
+        - Chat completions
+        - Speech to text
+        - Text to speech
+        - Translation
+        - Transliteration
+        - Language identification
+        - Document intelligence
+        - Other / multiple
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What would this recipe demonstrate?
+      description: "A short description of the use case and what a developer would learn from it."
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why would this be useful to other developers?
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: "I'm willing to submit a PR for this myself."
+          required: false
+        - label: "I've read CONTRIBUTING.md."
+          required: true


### PR DESCRIPTION
Related to #149

Adds `.github/ISSUE_TEMPLATE/`:
- `bug-report-example.yml` — for bugs in this repo's example code, with an upfront callout steering Indus app / Creator Studio / product reports elsewhere
- `recipe-proposal.yml` — for proposing new cookbook examples
- `config.yml` — disables blank issues, adds contact links

Contact link URLs currently point at #149 as a placeholder, per the
discussion there. @sucheet2000 is handling the README/CONTRIBUTING.md
routing wording in a separate PR to avoid overlapping with #159.
Both pieces are waiting on a maintainer to confirm the real
destinations for product/API/account issues — happy to update the
placeholder links once that's decided.